### PR TITLE
feat: dismissible option for Drawer.Root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-
-
-
 https://github.com/emilkowalski/vaul/assets/36730035/fdf8c5e8-ade8-433b-8bb0-4ce10e722516
-
 
 Vaul is an unstyled drawer component for React that can be used as a Dialog replacement on tablet and mobile devices. It uses [Radix's Dialog primitive](https://www.radix-ui.com/docs/primitives/components/dialog#trigger) under the hood and is inspired by [this tweet](https://twitter.com/devongovett/status/1674470185783402496).
 
@@ -36,7 +32,7 @@ function MyComponent() {
 
 ## Examples
 
-Play around with the examples on codesandbox: 
+Play around with the examples on codesandbox:
 
 - [With scaled background](https://codesandbox.io/p/sandbox/drawer-with-scale-g24vvh?file=%2Fapp%2Fmy-drawer.tsx%3A1%2C1)
 - [Without scaled background](https://codesandbox.io/p/sandbox/drawer-with-scale-forked-nx2glp?file=%2Fapp%2Fmy-drawer.tsx%3A4%2C1)
@@ -47,7 +43,7 @@ Play around with the examples on codesandbox:
 ### Root
 
 Contains all parts of a dialog. Use `shouldScaleBackground` to enable background scaling, it requires an element with `[vaul-drawer-wrapper]` data attribute to scale its background.
-Can be controlled with the `value` and `onOpenChange` props. Can be opened by default via `defaultOpen` prop.
+Can be controlled with the `value` and `onOpenChange` props. Can be opened by default via `defaultOpen` prop. Prevent dismissing by setting `dismissible` to `false`.
 
 ### Trigger
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,9 +63,17 @@ interface DialogProps {
   defaultOpen?: boolean;
   onOpenChange?(open: boolean): void;
   shouldScaleBackground?: boolean;
+  dismissible?: boolean;
 }
 
-function Root({ open: openProp, defaultOpen, onOpenChange, children, shouldScaleBackground }: DialogProps) {
+function Root({
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
+  children,
+  shouldScaleBackground,
+  dismissible = true,
+}: DialogProps) {
   const [isOpen = false, setIsOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen,
@@ -179,7 +187,7 @@ function Root({ open: openProp, defaultOpen, onOpenChange, children, shouldScale
         },
         true,
       );
-	  
+
       if (wrapper && overlayRef.current && shouldScaleBackground) {
         // Calculate percentageDragged as a fraction (0 to 1)
 
@@ -311,12 +319,12 @@ function Root({ open: openProp, defaultOpen, onOpenChange, children, shouldScale
       return;
     }
 
-    if (velocity > 0.4) {
+    if (velocity > 0.4 && dismissible) {
       closeDrawer();
       return;
     }
 
-    if (y > window.innerHeight * 0.75) {
+    if (y > window.innerHeight * 0.75 && dismissible) {
       closeDrawer();
       return;
     }
@@ -364,7 +372,7 @@ function Root({ open: openProp, defaultOpen, onOpenChange, children, shouldScale
       open={isOpen}
       onOpenChange={(o) => {
         setIsDragging(false);
-        setIsOpen(o);
+        setIsOpen(!dismissible || o);
       }}
     >
       <DrawerContext.Provider


### PR DESCRIPTION
Adds a boolean option `dismissible` to `<Drawer.Root />`

## Why?
There are many scenarios where a dialogue is non-dismissible. For example, when creating a cookie compliance modal, the user must either deny or accept cookies and should not be able to dismiss the modal. iOS drawers have this behavior where the user is for example forced to read the terms of service and either agree or reject. Considering this I thought it appropriate to have an easy-to-use non-default option to mimic this behavior natively within the library.

However, controlling the open state and preventing closing causes the drawer to "stick" since you can set `open` to always be `true` but you cannot call `resetDrawer()`. Furthermore, trying to reset the drawer position by setting the open state to `false` then one tick later setting it back to `true` does not work either.

## Can dismissible be controlled?

Yes, I've tested if you can still close and *enable* dismissibility at the same time:

Works ✅ 
```jsx
const [dismissible, setDismissible] = useState(false);
const [open, setOpen] = useState(false);

<Drawer.Root onOpenChange={setOpen} dismissible={dismissible} open={open}>
  <Drawer.Close>
    <button
      onClick={() => (setDismissible(true), setOpen(false))}
    >
      Close
    </button>
  </Drawer.Close>
</Drawer.Root>
```

Love the library btw, this is the only thing keeping our team at work from not using it via npm. Feel free to suggest/edit this PR. If you decide to close this PR we'll just use a fork, so all good, cheers 🍻 