### PR TITLE
Add support for multiple vaul-drawer-wrapper

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -177,7 +177,7 @@ function Root({
 
       // We need to capture last time when drag with scroll was triggered and have a timeout between
       const absDraggedDistance = Math.abs(draggedDistance);
-      const wrapper = document.querySelector('[vaul-drawer-wrapper]');
+      const wrappers = document.querySelectorAll('[vaul-drawer-wrapper]');
 
       const percentageDragged = absDraggedDistance / drawerHeight;
       const opacityValue = 1 - percentageDragged;
@@ -190,23 +190,24 @@ function Root({
         true,
       );
 
-      if (wrapper && overlayRef.current && shouldScaleBackground) {
+      if (wrappers.length > 0 && overlayRef.current && shouldScaleBackground) {
         // Calculate percentageDragged as a fraction (0 to 1)
 
         const scaleValue = Math.min(getScale() + percentageDragged * (1 - getScale()), 1);
         const borderRadiusValue = 8 - percentageDragged * 8;
 
         const translateYValue = Math.max(0, 14 - percentageDragged * 14);
-
-        set(
-          wrapper,
-          {
-            borderRadius: `${borderRadiusValue}px`,
-            transform: `scale(${scaleValue}) translateY(${translateYValue}px)`,
-            transition: 'none',
-          },
-          true,
-        );
+        wrappers.forEach((wrapper) => {
+          set(
+            wrapper,
+            {
+              borderRadius: `${borderRadiusValue}px`,
+              transform: `scale(${scaleValue}) translateY(${translateYValue}px)`,
+              transition: 'none',
+            },
+            true,
+          );
+        });
       }
 
       set(drawerRef.current, {
@@ -272,7 +273,7 @@ function Root({
   }, [isOpen]);
 
   function resetDrawer() {
-    const wrapper = document.querySelector('[vaul-drawer-wrapper]');
+    const wrappers = document.querySelectorAll('[vaul-drawer-wrapper]');
     const currentSwipeAmount = Number(
       getComputedStyle(drawerRef.current).getPropertyValue('--swipe-amount').slice(0, -2),
     );
@@ -284,19 +285,21 @@ function Root({
 
     // Don't reset background if swiped upwards
     if (shouldScaleBackground && currentSwipeAmount > 0 && isOpen) {
-      set(
-        wrapper,
-        {
-          borderRadius: `${BORDER_RADIUS}px`,
-          overflow: 'hidden',
-          transform: `scale(${getScale()}) translateY(calc(env(safe-area-inset-top) + 14px))`,
-          transformOrigin: 'top',
-          transitionProperty: 'transform, border-radius',
-          transitionDuration: `${TRANSITIONS.DURATION}s`,
-          transitionTimingFunction: `cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
-        },
-        true,
-      );
+      wrappers.forEach((wrapper) => {
+        set(
+          wrapper,
+          {
+            borderRadius: `${BORDER_RADIUS}px`,
+            overflow: 'hidden',
+            transform: `scale(${getScale()}) translateY(calc(env(safe-area-inset-top) + 14px))`,
+            transformOrigin: 'top',
+            transitionProperty: 'transform, border-radius',
+            transitionDuration: `${TRANSITIONS.DURATION}s`,
+            transitionTimingFunction: `cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
+          },
+          true,
+        );
+      });
     }
   }
 
@@ -337,9 +340,9 @@ function Root({
   }
 
   function onAnimationStart(e: React.AnimationEvent<HTMLDivElement>) {
-    const wrapper = document.querySelector('[vaul-drawer-wrapper]');
+    const wrappers = document.querySelectorAll('[vaul-drawer-wrapper]');
 
-    if (!wrapper || !shouldScaleBackground) return;
+    if (wrappers.length === 0 || !shouldScaleBackground) return;
 
     if (e.animationName === 'show-dialog') {
       set(
@@ -349,24 +352,27 @@ function Root({
         },
         true,
       );
-
-      set(wrapper, {
-        borderRadius: `${BORDER_RADIUS}px`,
-        overflow: 'hidden',
-        transform: `scale(${getScale()}) translateY(calc(env(safe-area-inset-top) + 14px))`,
-        transformOrigin: 'top',
-        transitionProperty: 'transform, border-radius',
-        transitionDuration: `${TRANSITIONS.DURATION}s`,
-        transitionTimingFunction: `cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
+      wrappers.forEach((wrapper) => {
+        set(wrapper, {
+          borderRadius: `${BORDER_RADIUS}px`,
+          overflow: 'hidden',
+          transform: `scale(${getScale()}) translateY(calc(env(safe-area-inset-top) + 14px))`,
+          transformOrigin: 'top',
+          transitionProperty: 'transform, border-radius',
+          transitionDuration: `${TRANSITIONS.DURATION}s`,
+          transitionTimingFunction: `cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
+        });
       });
     } else if (e.animationName === 'hide-dialog') {
       // Exit
-      reset(wrapper, 'transform');
-      reset(wrapper, 'borderRadius');
-      set(wrapper, {
-        transitionProperty: 'transform, border-radius',
-        transitionDuration: `${TRANSITIONS.DURATION}s`,
-        transitionTimingFunction: `cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
+      wrappers.forEach((wrapper) => {
+        reset(wrapper, 'transform');
+        reset(wrapper, 'borderRadius');
+        set(wrapper, {
+          transitionProperty: 'transform, border-radius',
+          transitionDuration: `${TRANSITIONS.DURATION}s`,
+          transitionTimingFunction: `cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
+        });
       });
     }
   }


### PR DESCRIPTION
Add support for multiple vaul-drawer-wrapper

## Why?

I am building an app that have a homepage on which there is a trigger to open the drawer. I also have a "sheet" modal that comes from the right and which also contains a trigger to open another drawer. It creates the following markup:

```html
<>
   <div vaul-drawer-wrapper="">
      main homepage content
      <HomepageDrawer/>
   <div>
   <SheetModal>
       sheet content
       <SheetDrawer/>
   </SheetModal>
</>
```

Given that the sheet modal needs to be in position fixed, inset 0, outside of the vaul-drawer-wrapper div, the background resizing is not visible for the drawer that is in the sheet. With my change, I can add a second vaul-drawer-wrapper attribute to the content of my sheet modal and it will also resize the background of the drawer inside the sheet modal.

To make it work before that, I added event handlers that just switched the attribute from the home content to the sheet content but it was not great to manage these refs between modals.

## How did I test the changes

I first created a demo in the website workspace (not committed to not ruin the design) which confirmed it worked. Then I built the library and tested it on my app and it worked great (I had to install @types/react and @types/react-dom and up the lib from es2015 to es2017, maybe we could commit that in another PR ?)

Great work overall, it is super smooth !