### PR TITLE
add scroll lock timeout option and fix endless drag prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Additional props:
 
 `closeTreshold`: Number between 0 and 1 that determines when the drawer should be closed. Example: `closeTreshold`` of 0.5 would close the drawer if the user swiped for 50% of the height of the drawer or more.
 
+`scrollLockTimeout`: Duration for which the drawer is not draggable after scrolling content inside of the drawer. Defaults to 1000ms
+
 ### Trigger
 
 The button that opens the dialog. [Props](https://www.radix-ui.com/docs/primitives/components/dialog#trigger).

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { usePreventScroll, isInput } from './use-prevent-scroll';
 import { useComposedRefs } from './use-composed-refs';
 
 const CLOSE_TRESHOLD = 0.75;
+const SCROLL_LOCK_TIMEOUT = 1000;
 
 const TRANSITIONS = {
   DURATION: 0.5,
@@ -80,6 +81,7 @@ interface DialogProps {
   closeTreshold?: number;
   onOpenChange?(open: boolean): void;
   shouldScaleBackground?: boolean;
+  scrollLockTimeout?: number;
   dismissible?: boolean;
   onDrag?(event: React.PointerEvent<HTMLDivElement>, percentageDragged: number): void;
   onRelease?(event: React.PointerEvent<HTMLDivElement>, open: boolean): void;
@@ -94,6 +96,7 @@ function Root({
   onDrag: onDragProp,
   onRelease: onReleaseProp,
   closeTreshold = CLOSE_TRESHOLD,
+  scrollLockTimeout = SCROLL_LOCK_TIMEOUT,
   dismissible = true,
 }: DialogProps) {
   const [isOpen = false, setIsOpen] = useControllableState({
@@ -105,7 +108,7 @@ function Root({
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const dragStartTime = React.useRef<Date | null>(null);
   const dragEndTime = React.useRef<Date | null>(null);
-  const lastTimeDragPrevented = React.useRef<Date | null>(null);
+  const lastTimeScrolled = React.useRef<Date | null>(null);
   const nestedOpenChangeTimer = React.useRef<NodeJS.Timeout>(null);
   const pointerStartY = React.useRef(0);
   const keyboardIsOpen = React.useRef(false);
@@ -149,8 +152,7 @@ function Root({
     }
 
     // Disallow dragging if drawer was scrolled within last second
-    if (lastTimeDragPrevented.current && date.getTime() - lastTimeDragPrevented.current.getTime() < 1000) {
-      lastTimeDragPrevented.current = new Date();
+    if (lastTimeScrolled.current && date.getTime() - lastTimeScrolled.current.getTime() < scrollLockTimeout) {
       return false;
     }
 
@@ -161,14 +163,14 @@ function Root({
         if (element.role === 'dialog' || element.getAttribute('vaul-drawer')) return true;
 
         if (element.scrollTop > 0) {
-          lastTimeDragPrevented.current = new Date();
+          lastTimeScrolled.current = new Date();
 
           // The element is scrollable and not scrolled to the top, so don't drag
           return false;
         }
 
         if (isDraggingDown && element !== document.body) {
-          lastTimeDragPrevented.current = new Date();
+          lastTimeScrolled.current = new Date();
           // Element is scrolled to the top, but we are dragging down so we should allow scrolling
           return false;
         }
@@ -413,7 +415,7 @@ function Root({
     const scale = o ? (window.innerWidth - 16) / window.innerWidth : 1;
     const y = o ? -16 : 0;
     window.clearTimeout(nestedOpenChangeTimer.current);
-	
+
     set(drawerRef.current, {
       transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
       transform: `scale(${scale}) translateY(${y}px)`,
@@ -568,7 +570,7 @@ function NestedRoot({ children, onDrag, onOpenChange }: DialogProps) {
   );
 }
 
-export const Drawer = Object.assign(
+export const Drawer: any = Object.assign(
   {},
   {
     Root,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -570,7 +570,7 @@ function NestedRoot({ children, onDrag, onOpenChange }: DialogProps) {
   );
 }
 
-export const Drawer: any = Object.assign(
+export const Drawer = Object.assign(
   {},
   {
     Root,


### PR DESCRIPTION
A user that tries to close the drawer within one second after scrolling inside content will be prevent from dragging the drawer. However if the user is impatient/confused and keeps trying to close the drawer, they will be endlessly stuck in a non-draggable drawer since the timer resets on every attempt. This PR fixes this timer reset and also exposes the timeout duration as an option since it was desirable for our project to tweak this timing and thus might be valuable to others too.

This PR:
- fixes the endlessly stuck drawer issue
- introduces an optional prop to control the scroll lock timeout