### PR TITLE
fix closeThreshold bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Additional props:
 
 `closeTreshold`: Number between 0 and 1 that determines when the drawer should be closed. Example: `closeTreshold`` of 0.5 would close the drawer if the user swiped for 50% of the height of the drawer or more.
 
+`scrollLockTimeout`: Duration for which the drawer is not draggable after scrolling content inside of the drawer. Defaults to 1000ms
+
 ### Trigger
 
 The button that opens the dialog. [Props](https://www.radix-ui.com/docs/primitives/components/dialog#trigger).

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import './style.css';
 import { usePreventScroll, isInput } from './use-prevent-scroll';
 import { useComposedRefs } from './use-composed-refs';
 
-const CLOSE_TRESHOLD = 0.75;
+const CLOSE_TRESHOLD = 0.25;
 const SCROLL_LOCK_TIMEOUT = 1000;
 
 const TRANSITIONS = {
@@ -358,6 +358,7 @@ function Root({
 
     const y = event.clientY;
 
+    const swipeAmountInt = Number.parseInt(swipeAmount, 10);
     const timeTaken = dragEndTime.current.getTime() - dragStartTime.current.getTime();
     const distMoved = pointerStartY.current - y;
     const velocity = Math.abs(distMoved) / timeTaken;
@@ -375,7 +376,9 @@ function Root({
       return;
     }
 
-    if (y > window.innerHeight * closeTreshold) {
+    const visibleDrawerHeight = Math.min(drawerRef.current?.getBoundingClientRect().height || 0, window.innerHeight);
+
+    if (swipeAmountInt >= visibleDrawerHeight * closeTreshold) {
       closeDrawer();
       onReleaseProp?.(event, false);
       return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -349,16 +349,15 @@ function Root({
     setIsDragging(false);
     dragEndTime.current = new Date();
     const swipeAmount = drawerRef.current
-      ? getComputedStyle(drawerRef.current).getPropertyValue('--swipe-amount').slice(0, -2)
+      ? Number.parseInt(getComputedStyle(drawerRef.current).getPropertyValue('--swipe-amount').slice(0, -2), 10)
       : null;
 
-    if (!shouldDrag(event.target, false) || !swipeAmount) return;
+    if (!shouldDrag(event.target, false) || !swipeAmount || Number.isNaN(swipeAmount)) return;
 
     if (dragStartTime.current === null) return;
 
     const y = event.clientY;
 
-    const swipeAmountInt = Number.parseInt(swipeAmount, 10);
     const timeTaken = dragEndTime.current.getTime() - dragStartTime.current.getTime();
     const distMoved = pointerStartY.current - y;
     const velocity = Math.abs(distMoved) / timeTaken;
@@ -378,7 +377,7 @@ function Root({
 
     const visibleDrawerHeight = Math.min(drawerRef.current?.getBoundingClientRect().height || 0, window.innerHeight);
 
-    if (swipeAmountInt >= visibleDrawerHeight * closeTreshold) {
+    if (swipeAmount >= visibleDrawerHeight * closeTreshold) {
       closeDrawer();
       onReleaseProp?.(event, false);
       return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { usePreventScroll, isInput } from './use-prevent-scroll';
 import { useComposedRefs } from './use-composed-refs';
 
 const CLOSE_TRESHOLD = 0.75;
+const SCROLL_LOCK_TIMEOUT = 1000;
 
 const TRANSITIONS = {
   DURATION: 0.5,
@@ -80,6 +81,7 @@ interface DialogProps {
   closeTreshold?: number;
   onOpenChange?(open: boolean): void;
   shouldScaleBackground?: boolean;
+  scrollLockTimeout?: number;
   dismissible?: boolean;
   onDrag?(event: React.PointerEvent<HTMLDivElement>, percentageDragged: number): void;
   onRelease?(event: React.PointerEvent<HTMLDivElement>, open: boolean): void;
@@ -94,6 +96,7 @@ function Root({
   onDrag: onDragProp,
   onRelease: onReleaseProp,
   closeTreshold = CLOSE_TRESHOLD,
+  scrollLockTimeout = SCROLL_LOCK_TIMEOUT,
   dismissible = true,
 }: DialogProps) {
   const [isOpen = false, setIsOpen] = useControllableState({
@@ -105,7 +108,7 @@ function Root({
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const dragStartTime = React.useRef<Date | null>(null);
   const dragEndTime = React.useRef<Date | null>(null);
-  const lastTimeDragPrevented = React.useRef<Date | null>(null);
+  const lastTimeScrolled = React.useRef<Date | null>(null);
   const nestedOpenChangeTimer = React.useRef<NodeJS.Timeout>(null);
   const pointerStartY = React.useRef(0);
   const keyboardIsOpen = React.useRef(false);
@@ -149,8 +152,7 @@ function Root({
     }
 
     // Disallow dragging if drawer was scrolled within last second
-    if (lastTimeDragPrevented.current && date.getTime() - lastTimeDragPrevented.current.getTime() < 1000) {
-      lastTimeDragPrevented.current = new Date();
+    if (lastTimeScrolled.current && date.getTime() - lastTimeScrolled.current.getTime() < scrollLockTimeout) {
       return false;
     }
 
@@ -161,14 +163,14 @@ function Root({
         if (element.role === 'dialog' || element.getAttribute('vaul-drawer')) return true;
 
         if (element.scrollTop > 0) {
-          lastTimeDragPrevented.current = new Date();
+          lastTimeScrolled.current = new Date();
 
           // The element is scrollable and not scrolled to the top, so don't drag
           return false;
         }
 
         if (isDraggingDown && element !== document.body) {
-          lastTimeDragPrevented.current = new Date();
+          lastTimeScrolled.current = new Date();
           // Element is scrolled to the top, but we are dragging down so we should allow scrolling
           return false;
         }
@@ -413,7 +415,7 @@ function Root({
     const scale = o ? (window.innerWidth - 16) / window.innerWidth : 1;
     const y = o ? -16 : 0;
     window.clearTimeout(nestedOpenChangeTimer.current);
-	
+
     set(drawerRef.current, {
       transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
       transform: `scale(${scale}) translateY(${y}px)`,
@@ -568,7 +570,7 @@ function NestedRoot({ children, onDrag, onOpenChange }: DialogProps) {
   );
 }
 
-export const Drawer = Object.assign(
+export const Drawer: any = Object.assign(
   {},
   {
     Root,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -570,7 +570,7 @@ function NestedRoot({ children, onDrag, onOpenChange }: DialogProps) {
   );
 }
 
-export const Drawer: any = Object.assign(
+export const Drawer = Object.assign(
   {},
   {
     Root,


### PR DESCRIPTION
The close threshold was not handled correctly and was causing issues with clicks/taps. When clicking on the sheet at a y-coordinate below the close threshold, the sheet would close. Expected behaviour is that it only closes after dragging, not on clicks and that it should close when the user swipes more than `closeThreshold * visibleDrawerHeight` regardless of the click/tap y-coordinate.

A video of the bug is attached below (note that we need to drag the sheet up first, because the bug only happens when `--swipe-amount` is set on the sheet)

https://github.com/emilkowalski/vaul/assets/9706105/21c29671-94a6-4fc6-ae9c-263637efc341

