### PR TITLE
Improve swiping in a scrollable drawer

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import { useComposedRefs } from './use-composed-refs';
 
 const CLOSE_THRESHOLD = 0.25;
 
-const SCROLL_LOCK_TIMEOUT = 1000;
+const SCROLL_LOCK_TIMEOUT = 500;
 
 const TRANSITIONS = {
   DURATION: 0.5,
@@ -110,7 +110,7 @@ function Root({
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const dragStartTime = React.useRef<Date | null>(null);
   const dragEndTime = React.useRef<Date | null>(null);
-  const lastTimeScrolled = React.useRef<Date | null>(null);
+  const lastTimeDragPrevented = React.useRef<Date | null>(null);
   const nestedOpenChangeTimer = React.useRef<NodeJS.Timeout>(null);
   const pointerStartY = React.useRef(0);
   const keyboardIsOpen = React.useRef(false);
@@ -149,7 +149,8 @@ function Root({
     }
 
     // Disallow dragging if drawer was scrolled within last second
-    if (lastTimeScrolled.current && date.getTime() - lastTimeScrolled.current.getTime() < scrollLockTimeout) {
+    if (lastTimeDragPrevented.current && date.getTime() - lastTimeDragPrevented.current.getTime() < scrollLockTimeout) {
+      lastTimeDragPrevented.current = new Date();
       return false;
     }
 
@@ -160,14 +161,14 @@ function Root({
         if (element.role === 'dialog' || element.getAttribute('vaul-drawer')) return true;
 
         if (element.scrollTop > 0) {
-          lastTimeScrolled.current = new Date();
+          lastTimeDragPrevented.current = new Date();
 
           // The element is scrollable and not scrolled to the top, so don't drag
           return false;
         }
 
         if (isDraggingDown && element !== document.body) {
-          lastTimeScrolled.current = new Date();
+          lastTimeDragPrevented.current = new Date();
           // Element is scrolled to the top, but we are dragging down so we should allow scrolling
           return false;
         }

--- a/website/src/app/components/hero.tsx
+++ b/website/src/app/components/hero.tsx
@@ -51,84 +51,36 @@ export function Hero() {
             </Drawer.Trigger>
             <Drawer.Overlay className="fixed inset-0 bg-black/40" />
             <Drawer.Portal>
-              <Drawer.Content className="bg-gray-100 flex flex-col rounded-t-[10px] h-full mt-24 max-h-[96%] fixed bottom-0 left-0 right-0">
-                <div className="p-4 bg-white rounded-t-[10px] flex-1">
-                  <div className="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-gray-300 mb-8" />
-                  <div className="max-w-md mx-auto">
-                    <Drawer.Title className="font-medium mb-4">Drawer for React.</Drawer.Title>
-                    <p className="text-gray-600 mb-2">
-                      This component can be used as a Dialog replacement on mobile and tablet devices.
-                    </p>
-                    <p className="text-gray-600 mb-2">It comes unstyled and has gesture-driven animations.</p>
-                    <p className="text-gray-600 mb-8">
-                      It uses{' '}
-                      <a
-                        href="https://www.radix-ui.com/docs/primitives/components/dialog"
-                        className="underline"
-                        target="_blank"
-                      >
-                        Radix's Dialog primitive
-                      </a>{' '}
-                      under the hood and is inspired by{' '}
-                      <a
-                        href="https://twitter.com/devongovett/status/1674470185783402496"
-                        className="underline"
-                        target="_blank"
-                      >
-                        this tweet.
-                      </a>
-                    </p>
-                  </div>
-                </div>
-                <div className="p-4 bg-gray-100 border-t border-gray-200 mt-auto">
-                  <div className="flex gap-6 justify-end max-w-md mx-auto">
-                    <a
-                      className="text-xs text-gray-600 flex items-center gap-0.25"
-                      href="https://github.com/emilkowalski/vaul"
-                      target="_blank"
-                    >
-                      GitHub
-                      <svg
-                        fill="none"
-                        height="16"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                        viewBox="0 0 24 24"
-                        width="16"
-                        aria-hidden="true"
-                        className="w-3 h-3 ml-1"
-                      >
-                        <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path>
-                        <path d="M15 3h6v6"></path>
-                        <path d="M10 14L21 3"></path>
-                      </svg>
-                    </a>
-                    <a
-                      className="text-xs text-gray-600 flex items-center gap-0.25"
-                      href="https://twitter.com/emilkowalski_"
-                      target="_blank"
-                    >
-                      Twitter
-                      <svg
-                        fill="none"
-                        height="16"
-                        stroke="currentColor"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                        viewBox="0 0 24 24"
-                        width="16"
-                        aria-hidden="true"
-                        className="w-3 h-3 ml-1"
-                      >
-                        <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path>
-                        <path d="M15 3h6v6"></path>
-                        <path d="M10 14L21 3"></path>
-                      </svg>
-                    </a>
-                  </div>
+              <Drawer.Content className="bg-white flex flex-col fixed bottom-0 left-0 right-0 max-h-[82vh] rounded-t-[10px]">
+                <div className="max-w-md w-full mx-auto flex flex-col overflow-auto p-4 rounded-t-[10px]">
+                  <input className="border border-gray-400 my-8" placeholder="Input" />
+                  <p>
+                    But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was
+                    born and I will give you a complete account of the system, and expound the actual teachings of the
+                    great explorer of the truth, the master-builder of human happiness. No one rejects, dislikes, or
+                    avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue
+                    pleasure rationally encounter consequences that are extremely painful. Nor again is there anyone who
+                    loves or pursues or desires to obtain pain of itself, because it is pain, but because occasionally
+                    circumstances occur in which toil and pain can procure him some great pleasure. To take a trivial
+                    example, which of us ever undertakes laborious physical exercise, except to obtain some advantage
+                    from it? But who has any right to find fault with a man who chooses to enjoy a pleasure that has no
+                    annoying consequences, or one who avoids a pain that produces no resultant pleasure?
+                  </p>
+                  <input className="border border-gray-400 my-8" placeholder="Input" />
+                  <p>
+                    On the other hand, we denounce with righteous indignation and dislike men who are so beguiled and
+                    demoralized by the charms of pleasure of the moment, so blinded by desire, that they cannot foresee
+                    the pain and trouble that are bound to ensue; and equal blame belongs to those who fail in their
+                    duty through weakness of will, which is the same as saying through shrinking from toil and pain.
+                    These cases are perfectly simple and easy to distinguish. In a free hour, when our power of choice
+                    is untrammelled and when nothing prevents our being able to do what we like best, every pleasure is
+                    to be welcomed and every pain avoided. But in certain circumstances and owing to the claims of duty
+                    or the obligations of business it will frequently occur that pleasures have to be repudiated and
+                    annoyances accepted. The wise man therefore always holds in these matters to this principle of
+                    selection: he rejects pleasures to secure other greater pleasures, or else he endures pains to avoid
+                    worse pains.
+                  </p>
+                  <input className="border border-gray-400 my-8" placeholder="Input" />
                 </div>
               </Drawer.Content>
             </Drawer.Portal>


### PR DESCRIPTION
Before, the swipe could close the drawer right when you reached the top of a scrollable container, which could be unintentional. Right now we have a treshold of 500ms before we actually allow to drag down after we reach the top.