### PR TITLE
fix: use WeakMap instead of Map to avoid memory leaks

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,7 @@ const ANIMATION_DURATION = 501;
 
 const BORDER_RADIUS = 8;
 
-const cache = new Map();
+const cache = new WeakMap();
 
 interface Style {
   [key: string]: string;


### PR DESCRIPTION
The cache here will retain the reference to the DOM node, change it to weakmap so that the memory will be managed automatically when the DOM node disappears