### PR TITLE
Close menu properly when controlled

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,7 @@ importers:
       '@types/react-dom': 18.2.7
       '@vercel/analytics': ^1.0.1
       autoprefixer: 10.4.14
+      clsx: ^2.0.0
       eslint: 8.45.0
       eslint-config-next: 13.4.10
       next: 13.4.10
@@ -74,6 +75,7 @@ importers:
       '@types/react-dom': 18.2.7
       '@vercel/analytics': 1.0.1
       autoprefixer: 10.4.14_postcss@8.4.26
+      clsx: 2.0.0
       eslint: 8.45.0
       eslint-config-next: 13.4.10_eslint@8.45.0+typescript@5.1.6
       next: 13.4.10_react-dom@18.2.0+react@18.2.0

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -74,15 +74,11 @@ function Root({
   modal = true,
   onClose,
 }: DialogProps) {
-  const [isOpen = false, setIsOpen] = useControllableState({
-    prop: openProp,
-    defaultProp: defaultOpen,
-    onChange: onOpenChange,
-  });
+  const [isOpen = false, setIsOpen] = React.useState<boolean>(false);
   // Not visible = translateY(100%)
-  const [visible, setVisible] = React.useState(false);
-  const [isDragging, setIsDragging] = React.useState(false);
-  const [justReleased, setJustReleased] = React.useState(false);
+  const [visible, setVisible] = React.useState<boolean>(false);
+  const [isDragging, setIsDragging] = React.useState<boolean>(false);
+  const [justReleased, setJustReleased] = React.useState<boolean>(false);
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const dragStartTime = React.useRef<Date | null>(null);
   const dragEndTime = React.useRef<Date | null>(null);
@@ -371,6 +367,20 @@ function Root({
       return () => clearTimeout(id);
     }
   }, [isOpen, shouldScaleBackground]);
+
+  // This can be done much better
+  React.useEffect(() => {
+    if (openProp) {
+      setIsOpen(true);
+    } else {
+      closeDrawer();
+    }
+  }, [openProp]);
+
+  // This can be done much better
+  React.useEffect(() => {
+    onOpenChange?.(isOpen);
+  }, [isOpen]);
 
   function resetDrawer() {
     if (!drawerRef.current) return;

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "@types/react-dom": "18.2.7",
     "@vercel/analytics": "^1.0.1",
     "autoprefixer": "10.4.14",
+    "clsx": "^2.0.0",
     "eslint": "8.45.0",
     "eslint-config-next": "13.4.10",
     "next": "13.4.10",


### PR DESCRIPTION
Previously when the menu was closed due to a changed in the `open` prop the drawer would close instantly. 