### PR TITLE
Body styles are removed on initial render by useEffect hook

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -41,7 +41,7 @@ export function reset(el: Element | HTMLElement | null, prop?: string) {
   let originalStyles = cache.get(el);
 
   if (!originalStyles) {
-    (el.style as any) = {};
+    // (el.style as any) = {};
     return;
   }
 

--- a/website/src/app/components/hero.tsx
+++ b/website/src/app/components/hero.tsx
@@ -1,8 +1,16 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Drawer } from 'vaul';
 
 export function Hero() {
+  useEffect(() => {
+    document.body.style.marginTop = '76px';
+    return () => {
+      document.body.style.marginTop = '';
+    };
+  }, []);
+
   return (
     <div className="relative">
       <div


### PR DESCRIPTION
When I'm setting some custom styles via `useEffect` hook (calculate navbar height and set `marginTop` equal to it's height) those styles are removed after `Drawers` render.
I've commented out a line that resets those styles, but I'm not quite sure this is a proper fix.
I've done some manual tests and haven't found any issue.