### PR TITLE
Cleanup wrapper styles on unmount

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -282,6 +282,16 @@ function Root({
   }
 
   React.useEffect(() => {
+    // Clean up the wrapper styles in case the drawer has been unmounted without closing it
+    const wrapper = document.querySelector('[vaul-drawer-wrapper]');
+    if (wrapper) {
+      return () => {
+        reset(wrapper);
+      };
+    }
+  }, []);
+
+  React.useEffect(() => {
     function onVisualViewportChange() {
       if (!drawerRef.current) return;
 


### PR DESCRIPTION
Unmount without closing the drawer resulted in bugged wrapper state.