### PR TITLE
fix: restore position setting on unmount #135

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -117,7 +117,7 @@ function Root({
     isDisabled: !isOpen || isDragging || !modal || justReleased || !hasBeenOpened,
   });
 
-  usePositionFixed({ isOpen, modal, nested, hasBeenOpened });
+  const { restorePositionSetting } = usePositionFixed({ isOpen, modal, nested, hasBeenOpened });
 
   function getScale() {
     return (window.innerWidth - WINDOW_TOP_OFFSET) / window.innerWidth;
@@ -294,8 +294,13 @@ function Root({
     const wrapper = document.querySelector('[vaul-drawer-wrapper]');
 
     if (wrapper) {
-      return () => scaleBackground(false);
+      return () => {
+        scaleBackground(false);
+        restorePositionSetting();
+      };
     }
+
+    return restorePositionSetting;
   }, []);
 
   React.useEffect(() => {

--- a/src/use-position-fixed.ts
+++ b/src/use-position-fixed.ts
@@ -99,4 +99,6 @@ export function usePositionFixed({
       restorePositionSetting();
     }
   }, [isOpen]);
+
+  return { restorePositionSetting };
 }


### PR DESCRIPTION
This PR makes it so that the position is properly reset whenever the drawer is unmounted.

@emilkowalski You can use this page for testing (although you need to unset the `overflow: hidden`'s on the body in `globals.css`).
[page.txt](https://github.com/emilkowalski/vaul/files/12804900/page.txt)

Fixes #135.