### PR TITLE
fix: rely on screenY in stead of clientY for determining drag distance

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -138,7 +138,7 @@ function Root({
     // Ensure we maintain correct pointer capture even when going outside of the drawer
     (event.target as HTMLElement).setPointerCapture(event.pointerId);
 
-    pointerStartY.current = event.clientY;
+    pointerStartY.current = event.screenY;
   }
 
   function shouldDrag(el: EventTarget, isDraggingDown: boolean) {
@@ -205,7 +205,7 @@ function Root({
   function onDrag(event: React.PointerEvent<HTMLDivElement>) {
     // We need to know how much of the drawer has been dragged in percentages so that we can transform background accordingly
     if (isDragging) {
-      const draggedDistance = pointerStartY.current - event.clientY;
+      const draggedDistance = pointerStartY.current - event.screenY;
       const isDraggingDown = draggedDistance > 0;
 
       // Disallow dragging down to close when first snap point is the active one and dismissible prop is set to false.
@@ -464,7 +464,7 @@ function Root({
 
     if (dragStartTime.current === null) return;
 
-    const y = event.clientY;
+    const y = event.screenY;
 
     const timeTaken = dragEndTime.current.getTime() - dragStartTime.current.getTime();
     const distMoved = pointerStartY.current - y;


### PR DESCRIPTION
The issue in #151 is caused by the `event.clientY` which is negative the second time the drawer opens on Safari after scrolling (for whatever reason...). Changing this value to `event.screenY` fixes the issue as can be seen in the before/after video attached below (sorry, it's hard to read due to the 10mb upload limit 😅).

If you want to test this yourself, see [this branch](https://github.com/andrejilderda/vaul/tree/fix/unable-to-close-drawer-on-ios-under-certain-circumstances-testsuite).

https://github.com/emilkowalski/vaul/assets/487182/797f3a57-425f-4994-addb-0d93502ddcb9

Note: 5 E2E tests fail, but this is also the case for `develop`.