### PR TITLE
Fix no scroll upon navigation

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -117,14 +117,19 @@ function Root({
     isDisabled: !isOpen || isDragging || !modal || justReleased || !hasBeenOpened,
   });
 
-  const { restorePositionSetting } = usePositionFixed({ isOpen, modal, nested, hasBeenOpened });
+  const { restorePositionSetting } = usePositionFixed({
+    isOpen,
+    modal,
+    nested,
+    hasBeenOpened,
+  });
 
   function getScale() {
     return (window.innerWidth - WINDOW_TOP_OFFSET) / window.innerWidth;
   }
 
   function onPress(event: React.PointerEvent<HTMLDivElement>) {
-    if ((!dismissible && !snapPoints) || isDragging) return;
+    if (!dismissible && !snapPoints) return;
     if (drawerRef.current && !drawerRef.current.contains(event.target as Node)) return;
     drawerHeightRef.current = drawerRef.current?.getBoundingClientRect().height || 0;
     setIsDragging(true);

--- a/src/use-position-fixed.ts
+++ b/src/use-position-fixed.ts
@@ -13,6 +13,7 @@ export function usePositionFixed({
   nested: boolean;
   hasBeenOpened: boolean;
 }) {
+  const [activeUrl, setActiveUrl] = React.useState(window.location.href);
   const scrollPos = React.useRef(0);
 
   function setPositionFixed() {
@@ -63,6 +64,11 @@ export function usePositionFixed({
       document.body.style.right = 'unset';
 
       requestAnimationFrame(() => {
+        if (activeUrl !== window.location.href) {
+          setActiveUrl(window.location.href);
+          return;
+        }
+
         window.scrollTo(x, y);
       });
 
@@ -98,7 +104,7 @@ export function usePositionFixed({
     } else {
       restorePositionSetting();
     }
-  }, [isOpen, hasBeenOpened]);
+  }, [isOpen, hasBeenOpened, activeUrl]);
 
   return { restorePositionSetting };
 }

--- a/src/use-position-fixed.ts
+++ b/src/use-position-fixed.ts
@@ -13,7 +13,7 @@ export function usePositionFixed({
   nested: boolean;
   hasBeenOpened: boolean;
 }) {
-  const [activeUrl, setActiveUrl] = React.useState(window.location.href);
+  const [activeUrl, setActiveUrl] = React.useState(typeof window !== 'undefined' ? window.location.href : '');
   const scrollPos = React.useRef(0);
 
   function setPositionFixed() {


### PR DESCRIPTION
Previously when the url has been changed due to a navigation within the drawer, scroll position was still getting restored to the one from when you opened the drawer, we don't want that when navigating.

Also disabling multi touch support for now to bring back better scroll behavior.