### PR TITLE
Passthrough overlay children

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -673,7 +673,7 @@ function Root({
 }
 
 const Overlay = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>(
-  function ({ children, ...rest }, ref) {
+  function (props, ref) {
     const { overlayRef, snapPoints, onRelease, shouldFade, isOpen, visible } = useDrawerContext();
     const composedRef = useComposedRefs(ref, overlayRef);
     const hasSnapPoints = snapPoints && snapPoints.length > 0;
@@ -686,7 +686,7 @@ const Overlay = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<
         vaul-overlay=""
         vaul-snap-points={isOpen && hasSnapPoints ? 'true' : 'false'}
         vaul-snap-points-overlay={isOpen && shouldFade ? 'true' : 'false'}
-        {...rest}
+        {...props}
       />
     );
   },


### PR DESCRIPTION
Currently, the children prop is being destructured from the dialog's overlay and staying unused. I'm not sure if this was intentional but wrapping the overlay around the content is a pretty common radix-ui practice (although not necessary. e.g. see https://github.com/radix-ui/themes/blob/300260e3c3ed5fc491129b192760aad6f96c38ac/packages/radix-ui-themes/src/components/dialog.tsx#L46C10-L56) and currently isn't possible because of this