### PR TITLE
Fix: Prevent sheet from exceeding boundaries of the last snap point while dragging

### DIFF
--- a/src/use-snap-points.ts
+++ b/src/use-snap-points.ts
@@ -178,6 +178,9 @@ export function useSnapPoints({
     if (activeSnapPointOffset === null) return;
     const newYValue = activeSnapPointOffset - draggedDistance;
 
+    // Don't do anything if we exceed the last(highest) snap point
+    if (newYValue < snapPointsOffset[snapPointsOffset.length - 1]) return;
+
     set(drawerRef.current, {
       transform: `translate3d(0, ${newYValue}px, 0)`,
     });


### PR DESCRIPTION
There's currently a bug I noticed that lets the drawer exceed the snap points boundaries. You can reproduce this by dragging down and as soon as the animation starts, switch to dragging up (without releasing). Is there any use case where this might be needed? If so maybe we can introduce a prop. Let me know

Sandbox: https://codesandbox.io/p/devbox/drawer-snap-points-forked-3xxclj?file=%2Fapp%2Fmy-drawer.tsx
Video: https://www.loom.com/share/db36353318114dedb964d320be8849fc?sid=05234bb7-f938-4666-aba4-b57bd1e993ae