### PR TITLE
Fix: Allow snapping to the first snap point

### DIFF
--- a/src/use-snap-points.ts
+++ b/src/use-snap-points.ts
@@ -115,8 +115,8 @@ export function useSnapPoints({
 
   React.useEffect(() => {
     if (activeSnapPointProp) {
-      const newIndex = snapPoints?.findIndex((snapPoint) => snapPoint === activeSnapPointProp) ?? null;
-      if (snapPointsOffset && newIndex && typeof snapPointsOffset[newIndex] === 'number') {
+      const newIndex = snapPoints?.findIndex((snapPoint) => snapPoint === activeSnapPointProp) ?? -1;
+      if (snapPointsOffset && newIndex !== -1 && typeof snapPointsOffset[newIndex] === 'number') {
         snapToPoint(snapPointsOffset[newIndex] as number);
       }
     }


### PR DESCRIPTION
Fixes #222 

The condition [here](https://github.com/emilkowalski/vaul/pull/223/files#diff-0ac317dea14b2b9b41020d54607d198389fc65de549dc798887b683418755d48L119) checks that `newIndex` is not null by truthiness, but it could fail when `newIndex` is 0 (which is a valid value) as well.
I've changed the fallback value of `newIndex` to -1 to be inline with `findIndex` returning -1 when there is no match, and updated the check accordingly.
