### PR TITLE
Fix useSnapPoints onRelease position

### DIFF
--- a/src/use-snap-points.ts
+++ b/src/use-snap-points.ts
@@ -137,8 +137,8 @@ export function useSnapPoints({
 
     const currentPosition =
       direction === 'bottom' || direction === 'right'
-        ? activeSnapPointOffset ?? 0 - draggedDistance
-        : activeSnapPointOffset ?? 0 + draggedDistance;
+        ? (activeSnapPointOffset ?? 0) - draggedDistance
+        : (activeSnapPointOffset ?? 0) + draggedDistance;
     const isOverlaySnapPoint = activeSnapPointIndex === fadeFromIndex - 1;
     const isFirst = activeSnapPointIndex === 0;
     const hasDraggedUp = draggedDistance > 0;


### PR DESCRIPTION
Fixes #225 

In `activeSnapPointOffset ?? 0 - draggedDistance`, `-` has more precedence than `??`, so it evaluates to `activeSnapPointOffset ?? (0 - draggedDistance)`, causing `currentPosition` to always be the active snap point regardless of the dragged distance.