### PR TITLE
fix: remove extra 'use client' directive

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,10 +7,5 @@ export default defineConfig({
   sourcemap: true,
   dts: true,
   format: ['esm', 'cjs'],
-  injectStyle: true,
-  esbuildOptions(options) {
-    options.banner = {
-      js: '"use client"',
-    };
-  },
+  injectStyle: true
 });


### PR DESCRIPTION
When using Next.js and SWC plugin coverage instrumentation, you will get this error due to the duplication of the use client directive:

```error
Error: 
  × The "use client" directive must be placed before other expressions. Move it to the top of the file to resolve this issue.
   ╭─[/node_modules/.pnpm/vaul@0.9.0_@types+react-dom@18.2.17_@types+react@18.2.43_react-dom@18.2.0_react@18.2.0/node_modules/vaul/dist/index.mjs:1:1]
 1 │ "use client"
 2 │ "use client";import * as L from "@radix-ui/react-dialog";
```

Since you've already go this included in the index, there's no need for this config option.
Removing the banner resolves the issue with the plugin.