### PR TITLE
Prevent pull to refresh gestures

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -413,7 +413,9 @@ function Root({
     }, 300);
 
     setTimeout(() => {
-      // reset(document.documentElement, 'scrollBehavior');
+      reset(document.documentElement, 'scrollBehavior');
+      reset(document.documentElement, 'overscrollBehavior');
+      reset(document.body, 'overscrollBehavior');
       if (snapPoints) {
         setActiveSnapPoint(snapPoints[0]);
       }
@@ -560,6 +562,10 @@ function Root({
     if (isOpen) {
       set(document.documentElement, {
         scrollBehavior: 'auto',
+        overscrollBehavior: 'none',
+      });
+      set(document.body, {
+        overscrollBehavior: 'none',
       });
 
       openTime.current = new Date();
@@ -587,8 +593,10 @@ function Root({
 
     if (open) {
       // setting original styles initially
+      reset(document.body, 'overscrollBehavior');
       set(document.body, {
         background: document.body.style.backgroundColor || document.body.style.background,
+        overscrollBehavior: 'none',
       });
       // setting body styles, with cache ignored, so that we can get correct original styles in reset
       set(


### PR DESCRIPTION
This sets the `overscroll-behavior` to none on the html/body tags while the drawer is open to ensure that the "Pull to refresh" gestures on Android and iOS will never be triggered while dragging the drawer.

This also fixes an issue where the `scroll-behavior` wasn't being reset