### PR TITLE
Make data-vaul-no-drag work if any parent matches

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -159,7 +159,7 @@ function Root({
     const swipeAmount = drawerRef.current ? getTranslate(drawerRef.current, direction) : null;
     const date = new Date();
 
-    if (element.hasAttribute('data-vaul-no-drag')) {
+    if (element.hasAttribute('data-vaul-no-drag') || element.closest('[data-vaul-no-drag]')) {
       return false;
     }
 


### PR DESCRIPTION
Currently, `data-vaul-no-drag` only worked if the dragged element is exactly the element that has the attribute. The expected behavior is it works if any of the parent (using `element.closest`) has the attribute. Fixes #266 