### PR TITLE
Fix position fixed causing layout shifts on standalone sites (pwa)

### DIFF
--- a/src/use-position-fixed.ts
+++ b/src/use-position-fixed.ts
@@ -96,7 +96,9 @@ export function usePositionFixed({
     if (nested || !hasBeenOpened) return;
     // This is needed to force Safari toolbar to show **before** the drawer starts animating to prevent a gnarly shift from happening
     if (isOpen) {
-      setPositionFixed();
+      // avoid for standalone mode (PWA)
+      const isStandalone = window.matchMedia('(display-mode: standalone)').matches;
+      !isStandalone && setPositionFixed();
 
       if (!modal) {
         setTimeout(() => {


### PR DESCRIPTION
I simply added a new condition to only call setPositionFixed when display mode is set to standalone like in most PWA's.

Solves #199 where you can find more details about the problem. I personally don't think this needs an extra prop for more control over this behaviour but maybe there is a good reason for including one? 