### PR TITLE
fix: `onOpenChange` getting called twice when user clicks outside of the drawer

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -831,7 +831,6 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
           keyboardIsOpen.current = false;
         }
         e.preventDefault();
-        onOpenChange?.(false);
         if (!dismissible || openProp !== undefined) {
           return;
         }


### PR DESCRIPTION
Fixes: https://github.com/emilkowalski/vaul/issues/290

I tried to test as many possibilities as I could, and I couldn't find anything that breaks by deleting that line of code.