### PR TITLE
Export DialogProps type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ interface WithoutFadeFromProps {
   fadeFromIndex?: never;
 }
 
-type DialogProps = {
+export type DialogProps = {
   activeSnapPoint?: number | string | null;
   setActiveSnapPoint?: (snapPoint: number | string | null) => void;
   children?: React.ReactNode;


### PR DESCRIPTION
When trying to use Vaul in a component library that also re-exports TypeScript types (via something like `vite-plugin-dts`), type generation would fail with an external module error:
```
error TS4023: Exported variable 'Root' has or is using name 'WithFadeFromProps' from external module "/%project%/node_modules/vaul/dist/index" but cannot be named.
```

Marking `DialogProps` with an `export` keyword fixes this issue. There's also a bonus of not having to use `React.ComponentProps<T>` when the type is properly exported from the library.