### PR TITLE
Use CSS Animations for entry and exit animations

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,7 @@ export const TRANSITIONS = {
 };
 
 export const VELOCITY_THRESHOLD = 0.4;
+
+export const BORDER_RADIUS = 8;
+
+export const WINDOW_TOP_OFFSET = 26;

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,6 @@ import { DrawerDirection } from './types';
 interface DrawerContextValue {
   drawerRef: React.RefObject<HTMLDivElement>;
   overlayRef: React.RefObject<HTMLDivElement>;
-  scaleBackground: (open: boolean) => void;
   onPress: (event: React.PointerEvent<HTMLDivElement>) => void;
   onRelease: (event: React.PointerEvent<HTMLDivElement>) => void;
   onDrag: (event: React.PointerEvent<HTMLDivElement>) => void;
@@ -26,12 +25,13 @@ interface DrawerContextValue {
   openProp?: boolean;
   onOpenChange?: (o: boolean) => void;
   direction?: DrawerDirection;
+  shouldScaleBackground: boolean;
+  onClose: () => void;
 }
 
 export const DrawerContext = React.createContext<DrawerContextValue>({
   drawerRef: { current: null },
   overlayRef: { current: null },
-  scaleBackground: () => {},
   onPress: () => {},
   onRelease: () => {},
   onDrag: () => {},
@@ -53,6 +53,8 @@ export const DrawerContext = React.createContext<DrawerContextValue>({
   closeDrawer: () => {},
   setVisible: () => {},
   direction: 'bottom',
+  shouldScaleBackground: false,
+  onClose: () => {},
 });
 
 export const useDrawerContext = () => React.useContext(DrawerContext);

--- a/src/context.ts
+++ b/src/context.ts
@@ -28,7 +28,6 @@ interface DrawerContextValue {
   onOpenChange?: (o: boolean) => void;
   direction?: DrawerDirection;
   shouldScaleBackground: boolean;
-  onClose: () => void;
   setBackgroundColorOnScale: boolean;
   noBodyStyles: boolean;
 }
@@ -60,7 +59,6 @@ export const DrawerContext = React.createContext<DrawerContextValue>({
   setVisible: () => {},
   direction: 'bottom',
   shouldScaleBackground: false,
-  onClose: () => {},
   setBackgroundColorOnScale: true,
   noBodyStyles: false,
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { DrawerDirection } from './types';
+import { AnyFunction, DrawerDirection } from './types';
 
 interface Style {
   [key: string]: string;
@@ -89,4 +89,29 @@ export function getTranslate(element: HTMLElement, direction: DrawerDirection): 
 
 export function dampenValue(v: number) {
   return 8 * (Math.log(v + 1) - 2);
+}
+
+export function assignStyle(element: HTMLElement | null | undefined, style: Partial<CSSStyleDeclaration>) {
+  if (!element) return () => {};
+
+  const prevStyle = element.style.cssText;
+  Object.assign(element.style, style);
+
+  return () => {
+    element.style.cssText = prevStyle;
+  };
+}
+
+/**
+ * Receives functions as arguments and returns a new function that calls all.
+ */
+export function chain<T>(...fns: T[]) {
+  return (...args: T extends AnyFunction ? Parameters<T> : never) => {
+    for (const fn of fns) {
+      if (typeof fn === 'function') {
+        // @ts-ignore
+        fn(...args);
+      }
+    }
+  };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -409,6 +409,7 @@ function Root({
   const closeDrawer = React.useCallback(() => {
     cancelDrag();
     onClose?.();
+    setIsOpen(false);
     setVisible(false);
 
     setTimeout(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -93,7 +93,6 @@ function Root({
   const [hasBeenOpened, setHasBeenOpened] = React.useState<boolean>(false);
   // Not visible = translateY(100%)
   const [visible, setVisible] = React.useState<boolean>(false);
-  // const [mounted, setMounted] = React.useState<boolean>(false);
   const [isDragging, setIsDragging] = React.useState<boolean>(false);
   const [justReleased, setJustReleased] = React.useState<boolean>(false);
   const overlayRef = React.useRef<HTMLDivElement>(null);
@@ -413,7 +412,7 @@ function Root({
     return () => window.visualViewport?.removeEventListener('resize', onVisualViewportChange);
   }, [activeSnapPointIndex, snapPoints, snapPointsOffset]);
 
-  const closeDrawer = React.useCallback(() => {
+  function closeDrawer() {
     cancelDrag();
     onClose?.();
     setIsOpen(false);
@@ -425,7 +424,7 @@ function Root({
         setActiveSnapPoint(snapPoints[0]);
       }
     }, TRANSITIONS.DURATION * 1000); // seconds to ms
-  }, []);
+  }
 
   function resetDrawer() {
     if (!drawerRef.current) return;
@@ -658,7 +657,6 @@ function Root({
           snapPointsOffset,
           direction,
           shouldScaleBackground,
-          onClose: closeDrawer,
           setBackgroundColorOnScale,
           noBodyStyles,
         }}
@@ -821,7 +819,7 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
     direction,
     isOpen,
     snapPoints,
-    onClose,
+    closeDrawer,
   } = useDrawerContext();
   const composedRef = useComposedRefs(ref, drawerRef);
   const pointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
@@ -858,8 +856,8 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
   }, []);
 
   React.useEffect(() => {
-    if (!isOpen) onClose();
-  }, [onClose, isOpen]);
+    if (!isOpen) closeDrawer();
+  }, [closeDrawer, isOpen]);
 
   useScaleBackground();
 
@@ -902,13 +900,6 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
         if (keyboardIsOpen.current) {
           keyboardIsOpen.current = false;
         }
-        // e.preventDefault();
-        // onOpenChange?.(false);
-        // if (!dismissible || openProp !== undefined) {
-        //   return;
-        // }
-
-        // closeDrawer();
       }}
       onFocusOutside={(e) => {
         if (!modal) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import { useSnapPoints } from './use-snap-points';
 import { set, reset, getTranslate, dampenValue, isVertical } from './helpers';
 import { TRANSITIONS, VELOCITY_THRESHOLD } from './constants';
 import { DrawerDirection } from './types';
+import { useControllableState } from './use-controllable-state';
 
 const CLOSE_THRESHOLD = 0.25;
 
@@ -38,6 +39,7 @@ type DialogProps = {
   activeSnapPoint?: number | string | null;
   setActiveSnapPoint?: (snapPoint: number | string | null) => void;
   children?: React.ReactNode;
+  defaultOpen?: boolean;
   open?: boolean;
   closeThreshold?: number;
   onOpenChange?: (open: boolean) => void;
@@ -56,6 +58,7 @@ type DialogProps = {
 } & (WithFadeFromProps | WithoutFadeFromProps);
 
 function Root({
+  defaultOpen,
   open: openProp,
   onOpenChange,
   children,
@@ -77,11 +80,15 @@ function Root({
   preventScrollRestoration = true,
   disablePreventScroll = false,
 }: DialogProps) {
-  const [isOpen = false, setIsOpen] = React.useState<boolean>(false);
+  const [isOpen = false, setIsOpen] = useControllableState({
+    defaultProp: defaultOpen,
+    prop: openProp,
+    onChange: onOpenChange,
+  });
   const [hasBeenOpened, setHasBeenOpened] = React.useState<boolean>(false);
   // Not visible = translateY(100%)
   const [visible, setVisible] = React.useState<boolean>(false);
-  const [mounted, setMounted] = React.useState<boolean>(false);
+  // const [mounted, setMounted] = React.useState<boolean>(false);
   const [isDragging, setIsDragging] = React.useState<boolean>(false);
   const [justReleased, setJustReleased] = React.useState<boolean>(false);
   const overlayRef = React.useRef<HTMLDivElement>(null);
@@ -407,24 +414,22 @@ function Root({
     cancelDrag();
 
     onClose?.();
-    set(drawerRef.current, {
-      transform: isVertical(direction)
-        ? `translate3d(0, ${direction === 'bottom' ? '100%' : '-100%'}, 0)`
-        : `translate3d(${direction === 'right' ? '100%' : '-100%'}, 0, 0)`,
-      transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
-    });
-
-    set(overlayRef.current, {
-      opacity: '0',
-      transition: `opacity ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
-    });
-
+    // set(drawerRef.current, {
+    //   transform: isVertical(direction)
+    //     ? `translate3d(0, ${direction === 'bottom' ? '100%' : '-100%'}, 0)`
+    //     : `translate3d(${direction === 'right' ? '100%' : '-100%'}, 0, 0)`,
+    //   transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
+    // });
+    //
+    // set(overlayRef.current, {
+    //   opacity: '0',
+    //   transition: `opacity ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
+    // });
+    //
     scaleBackground(false);
 
-    setTimeout(() => {
-      setVisible(false);
-      setIsOpen(false);
-    }, 300);
+    setVisible(false);
+    // setIsOpen(false);
 
     setTimeout(() => {
       // reset(document.documentElement, 'scrollBehavior');
@@ -446,25 +451,25 @@ function Root({
   }, [isOpen, shouldScaleBackground]);
 
   // LayoutEffect to prevent extra render where openProp and isOpen are not synced yet
-  React.useLayoutEffect(() => {
-    if (openProp) {
-      setIsOpen(true);
-      setHasBeenOpened(true);
-    } else {
-      closeDrawer();
-    }
-  }, [openProp]);
+  // React.useLayoutEffect(() => {
+  //   if (openProp) {
+  //     setIsOpen(true);
+  //     setHasBeenOpened(true);
+  //   } else {
+  //     closeDrawer();
+  //   }
+  // }, [openProp]);
 
   // This can be done much better
-  React.useEffect(() => {
-    if (mounted) {
-      onOpenChange?.(isOpen);
-    }
-  }, [isOpen]);
+  // React.useEffect(() => {
+  //   if (mounted) {
+  //     onOpenChange?.(isOpen);
+  //   }
+  // }, [isOpen]);
 
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
+  // React.useEffect(() => {
+  //   setMounted(true);
+  // }, []);
 
   function resetDrawer() {
     if (!drawerRef.current) return;
@@ -711,18 +716,11 @@ function Root({
   return (
     <DialogPrimitive.Root
       modal={modal}
-      onOpenChange={(o: boolean) => {
-        if (openProp !== undefined) {
-          onOpenChange?.(o);
-          return;
-        }
-
-        if (!o) {
-          closeDrawer();
-        } else {
-          setHasBeenOpened(true);
-          setIsOpen(o);
-        }
+      defaultOpen={defaultOpen}
+      onOpenChange={(open) => {
+        if (open) setHasBeenOpened(true);
+        else closeDrawer();
+        setIsOpen(open);
       }}
       open={isOpen}
     >
@@ -805,9 +803,12 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
     onOpenChange,
     setVisible,
     direction,
+    isOpen,
+    snapPoints,
   } = useDrawerContext();
   const composedRef = useComposedRefs(ref, drawerRef);
   const pointerStartRef = React.useRef<{ x: number; y: number } | null>(null);
+  const hasSnapPoints = snapPoints && snapPoints.length > 0;
 
   React.useEffect(() => {
     // Trigger enter animation without using CSS animation
@@ -830,6 +831,7 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
       vaul-drawer=""
       vaul-drawer-direction={direction}
       vaul-drawer-visible={visible ? 'true' : 'false'}
+      vaul-snap-points={isOpen && hasSnapPoints ? 'true' : 'false'}
       {...rest}
       ref={composedRef}
       style={
@@ -862,13 +864,13 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
         if (keyboardIsOpen.current) {
           keyboardIsOpen.current = false;
         }
-        e.preventDefault();
-        onOpenChange?.(false);
-        if (!dismissible || openProp !== undefined) {
-          return;
-        }
+        // e.preventDefault();
+        // onOpenChange?.(false);
+        // if (!dismissible || openProp !== undefined) {
+        //   return;
+        // }
 
-        closeDrawer();
+        // closeDrawer();
       }}
       onPointerMove={(event) => {
         rest.onPointerMove?.(event);

--- a/src/style.css
+++ b/src/style.css
@@ -1,21 +1,51 @@
 [vaul-drawer] {
   touch-action: none;
   transition: transform 0.5s cubic-bezier(0.32, 0.72, 0, 1);
+  animation-duration: 0.5s;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-[vaul-drawer][vaul-drawer-direction='bottom'] {
+[vaul-drawer][vaul-snap-points='false'][vaul-drawer-direction='bottom'][data-state='open'] {
+  animation-name: slideFromBottom;
+}
+[vaul-drawer][vaul-snap-points='false'][vaul-drawer-direction='bottom'][data-state='closed'] {
+  animation-name: slideToBottom;
+}
+
+[vaul-drawer][vaul-snap-points='false'][vaul-drawer-direction='top'][data-state='open'] {
+  animation-name: slideFromTop;
+}
+[vaul-drawer][vaul-snap-points='false'][vaul-drawer-direction='top'][data-state='closed'] {
+  animation-name: slideToTop;
+}
+
+[vaul-drawer][vaul-snap-points='false'][vaul-drawer-direction='left'][data-state='open'] {
+  animation-name: slideFromLeft;
+}
+[vaul-drawer][vaul-snap-points='false'][vaul-drawer-direction='left'][data-state='closed'] {
+  animation-name: slideToLeft;
+}
+
+[vaul-drawer][vaul-snap-points='false'][vaul-drawer-direction='right'][data-state='open'] {
+  animation-name: slideFromRight;
+}
+[vaul-drawer][vaul-snap-points='false'][vaul-drawer-direction='right'][data-state='closed'] {
+  animation-name: slideToRight;
+}
+
+[vaul-drawer][vaul-snap-points='true'][vaul-drawer-direction='bottom'] {
   transform: translate3d(0, 100%, 0);
 }
 
-[vaul-drawer][vaul-drawer-direction='top'] {
+[vaul-drawer][vaul-snap-points='true'][vaul-drawer-direction='top'] {
   transform: translate3d(0, -100%, 0);
 }
 
-[vaul-drawer][vaul-drawer-direction='left'] {
+[vaul-drawer][vaul-snap-points='true'][vaul-drawer-direction='left'] {
   transform: translate3d(-100%, 0, 0);
 }
 
-[vaul-drawer][vaul-drawer-direction='right'] {
+[vaul-drawer][vaul-snap-points='true'][vaul-drawer-direction='right'] {
   transform: translate3d(100%, 0, 0);
 }
 
@@ -34,19 +64,19 @@
   overflow-x: hidden !important;
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][vaul-drawer-direction='top'] {
+[vaul-drawer][vaul-snap-points='true'][vaul-drawer-visible='true'][vaul-drawer-direction='top'] {
   transform: translate3d(0, var(--snap-point-height, 0), 0);
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][vaul-drawer-direction='bottom'] {
+[vaul-drawer][vaul-snap-points='true'][vaul-drawer-visible='true'][vaul-drawer-direction='bottom'] {
   transform: translate3d(0, var(--snap-point-height, 0), 0);
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][vaul-drawer-direction='left'] {
+[vaul-drawer][vaul-snap-points='true'][vaul-drawer-visible='true'][vaul-drawer-direction='left'] {
   transform: translate3d(var(--snap-point-height, 0), 0, 0);
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][vaul-drawer-direction='right'] {
+[vaul-drawer][vaul-snap-points='true'][vaul-drawer-visible='true'][vaul-drawer-direction='right'] {
   transform: translate3d(var(--snap-point-height, 0), 0, 0);
 }
 
@@ -111,5 +141,65 @@
   from {
   }
   to {
+  }
+}
+
+@keyframes slideFromBottom {
+  from {
+    transform: translate3d(0, 100%, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes slideToBottom {
+  to {
+    transform: translate3d(0, 100%, 0);
+  }
+}
+
+@keyframes slideFromTop {
+  from {
+    transform: translate3d(0, -100%, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes slideToTop {
+  to {
+    transform: translate3d(0, -100%, 0);
+  }
+}
+
+@keyframes slideFromLeft {
+  from {
+    transform: translate3d(-100%, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes slideToLeft {
+  to {
+    transform: translate3d(-100%, 0, 0);
+  }
+}
+
+@keyframes slideFromRight {
+  from {
+    transform: translate3d(100%, 0, 0);
+  }
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes slideToRight {
+  to {
+    transform: translate3d(100%, 0, 0);
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -80,12 +80,23 @@
   transform: translate3d(var(--snap-point-height, 0), 0, 0);
 }
 
-[vaul-overlay] {
+[vaul-overlay][vaul-snap-points='false'] {
+  animation-duration: 0.5s;
+  animation-timing-function: cubic-bezier(0.32, 0.72, 0, 1);
+}
+[vaul-overlay][vaul-snap-points='false'][data-state='open'] {
+  animation-name: fadeIn;
+}
+[vaul-overlay][vaul-snap-points='false'][data-state='closed'] {
+  animation-name: fadeOut;
+}
+
+[vaul-overlay][vaul-snap-points='true'] {
   opacity: 0;
   transition: opacity 0.5s cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-[vaul-overlay][vaul-drawer-visible='true'] {
+[vaul-overlay][vaul-snap-points='true'][vaul-drawer-visible='true'] {
   opacity: 1;
 }
 
@@ -141,6 +152,21 @@
   from {
   }
   to {
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  to {
+    opacity: 0;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,4 @@ export interface SnapPoint {
   fraction: number;
   height: number;
 }
+export type AnyFunction = (...args: any) => any;

--- a/src/use-scale-background.ts
+++ b/src/use-scale-background.ts
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useDrawerContext } from './context';
+import { assignStyle, chain, isVertical } from './helpers';
+import { BORDER_RADIUS, TRANSITIONS, WINDOW_TOP_OFFSET } from './constants';
+
+export function useScaleBackground() {
+  const { direction, isOpen, shouldScaleBackground } = useDrawerContext();
+  const timeoutIdRef = React.useRef<number | null>(null);
+
+  function getScale() {
+    return (window.innerWidth - WINDOW_TOP_OFFSET) / window.innerWidth;
+  }
+
+  React.useEffect(() => {
+    if (isOpen && shouldScaleBackground) {
+      if (timeoutIdRef.current) clearTimeout(timeoutIdRef.current);
+      const wrapper = document.querySelector('[vaul-drawer-wrapper]') as HTMLElement;
+
+      const bodyAndWrapperCleanup = chain(
+        assignStyle(document.body, { background: 'black' }),
+        assignStyle(wrapper, {
+          transformOrigin: isVertical(direction) ? 'top' : 'left',
+          transitionProperty: 'transform, border-radius',
+          transitionDuration: `${TRANSITIONS.DURATION}s`,
+          transitionTimingFunction: `cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
+        }),
+      );
+      const wrapperStylesCleanup = assignStyle(wrapper, {
+        borderRadius: `${BORDER_RADIUS}px`,
+        overflow: 'hidden',
+        ...(isVertical(direction)
+          ? {
+              transform: `scale(${getScale()}) translate3d(0, calc(env(safe-area-inset-top) + 14px), 0)`,
+            }
+          : {
+              transform: `scale(${getScale()}) translate3d(calc(env(safe-area-inset-top) + 14px), 0, 0)`,
+            }),
+      });
+
+      return () => {
+        wrapperStylesCleanup();
+        timeoutIdRef.current = window.setTimeout(() => {
+          bodyAndWrapperCleanup();
+        }, TRANSITIONS.DURATION * 1000);
+      };
+    }
+  }, [isOpen, shouldScaleBackground]);
+}

--- a/test/src/app/controlled/page.tsx
+++ b/test/src/app/controlled/page.tsx
@@ -9,8 +9,8 @@ export default function Page() {
 
   return (
     <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" vaul-drawer-wrapper="">
-      <Drawer.Root open={open}>
-        <Drawer.Trigger asChild onClick={() => setOpen(true)}>
+      <Drawer.Root open={open} onOpenChange={setOpen}>
+        <Drawer.Trigger asChild>
           <button data-testid="trigger" className="text-2xl">
             Open Drawer
           </button>
@@ -118,7 +118,7 @@ export default function Page() {
             className="bg-zinc-100 flex flex-col rounded-t-[10px] h-[96%] mt-24 fixed bottom-0 left-0 right-0"
           >
             <Drawer.Close data-testid="drawer-close">Close</Drawer.Close>
-            <button data-testid="controlled-close" onClick={() => setOpen(false)} className="text-2xl">
+            <button data-testid="controlled-close" onClick={() => setFullyControlled(false)} className="text-2xl">
               Close
             </button>
             <div className="p-4 bg-white rounded-t-[10px] flex-1">

--- a/test/src/app/with-scaled-background/page.tsx
+++ b/test/src/app/with-scaled-background/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { forwardRef, useState } from 'react';
 import clsx from 'clsx';
 import { Drawer } from 'vaul';
 import { DrawerDirection } from 'vaul/src/types';
@@ -26,9 +26,10 @@ const CenteredContent = () => {
   );
 };
 
-const DrawerContent = ({ drawerDirection }: { drawerDirection: DrawerDirection }) => {
+const DrawerContent = forwardRef<HTMLDivElement, { drawerDirection: DrawerDirection }>(({ drawerDirection }, ref) => {
   return (
     <Drawer.Content
+      ref={ref}
       data-testid="content"
       className={clsx({
         'bg-zinc-100 flex fixed p-6': true,
@@ -60,7 +61,7 @@ const DrawerContent = ({ drawerDirection }: { drawerDirection: DrawerDirection }
       </div>
     </Drawer.Content>
   );
-};
+});
 
 export default function Page() {
   const [direction, setDirection] = useState<DrawerDirection>('bottom');


### PR DESCRIPTION
This PR adds the use of CSS animations for Vaul entry and exit animations, making the code for managing the open state simpler.

I also refactored the logic of the scaleBackground function by changing

- Taking advantage of the `Content` component to be mounted/unmounted when the dialog is open or closed
- Created two utility functions `assignStyle` and `chain` that together facilitate the editing of styles and their cleaning

Fixes #292 