### PR TITLE
use useIsomorphicLayoutEffect instead of useLayoutEffect to avoid the warning log

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import React, { useRef, useState } from 'react';
 import { DrawerContext, useDrawerContext } from './context';
 import './style.css';
-import { usePreventScroll, isInput, isIOS } from './use-prevent-scroll';
+import { usePreventScroll, isInput, isIOS, useIsomorphicLayoutEffect } from './use-prevent-scroll';
 import { useComposedRefs } from './use-composed-refs';
 import { usePositionFixed } from './use-position-fixed';
 import { useSnapPoints } from './use-snap-points';
@@ -453,7 +453,7 @@ function Root({
   }, [isOpen, shouldScaleBackground]);
 
   // LayoutEffect to prevent extra render where openProp and isOpen are not synced yet
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (openProp) {
       setIsOpen(true);
       setHasBeenOpened(true);


### PR DESCRIPTION
We are using nextjs and see the below warning log. 

website-api-gateway:dev: Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
