### PR TITLE
Export types and interfaces related to DialogProps

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,17 +24,17 @@ const WINDOW_TOP_OFFSET = 26;
 
 const DRAG_CLASS = 'vaul-dragging';
 
-interface WithFadeFromProps {
+export interface WithFadeFromProps {
   snapPoints: (number | string)[];
   fadeFromIndex: number;
 }
 
-interface WithoutFadeFromProps {
+export interface WithoutFadeFromProps {
   snapPoints?: (number | string)[];
   fadeFromIndex?: never;
 }
 
-type DialogProps = {
+export type DialogProps = {
   activeSnapPoint?: number | string | null;
   setActiveSnapPoint?: (snapPoint: number | string | null) => void;
   children?: React.ReactNode;


### PR DESCRIPTION
## Issue

When I create a meta object for a storybook story setup in the following way, TS throws an error as it's not able to pick up definitions for WithFade

```drawer.tsx
// components/drawer.tsx
import { Drawer as DrawerPrimitive } from 'vaul'

export type DrawerProps = React.ComponentProps<typeof DrawerPrimitive.Root>
```

```drawer.stories.tsx
// stories/drawer.stories.tsx
import { Drawer } from '@/components/drawer'

// this throws 2 TS error
const meta = {
  title: 'Drawer',
  component: Drawer
} satisfies Meta<typeof Drawer>
```

Here's the TS errors

```txt
Exported variable 'meta' has or is using name 'WithoutFadeFromProps' from external module
```

```txt
Exported variable 'meta' has or is using name 'WithFadeFromProps' from external module
```

## Fix

Export the `WithFadeFromProps` and `WithoutFadeFromProps` TS types. 