### PR TITLE
ISSUE-369: Make vaul use data- attr for Content direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Play around with the examples on codesandbox:
 
 ### Root
 
-Contains all parts of a dialog. Use `shouldScaleBackground` to enable background scaling, it requires an element with `[vaul-drawer-wrapper]` data attribute to scale its background.
+Contains all parts of a dialog. Use `shouldScaleBackground` to enable background scaling, it requires an element with `[data-vaul-drawer-wrapper]` data attribute to scale its background.
 Can be controlled with the `value` and `onOpenChange` props. Can be opened by default via the `open` prop.
 
 Additional props:
@@ -103,7 +103,7 @@ The button that closes the dialog. [Props](https://www.radix-ui.com/docs/primiti
 
 ### Handle
 
-A drag hint (also known as grabber). Shows people that they can drag the drawer to resize it; they can also tap it to cycle through the snap points, and double tap quickly to close the drawer. Set `preventCycle={true}` to stop this behavior. If you want to change the handle's hit area you can do so by styling the `[vaul-handle-hitarea]` selector (Defaults to 44x44 on mobile devices).
+A drag hint (also known as grabber). Shows people that they can drag the drawer to resize it; they can also tap it to cycle through the snap points, and double tap quickly to close the drawer. Set `preventCycle={true}` to stop this behavior. If you want to change the handle's hit area you can do so by styling the `[data-vaul-handle-hitarea]` selector (Defaults to 44x44 on mobile devices).
 
 ### Portal
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -964,8 +964,8 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
   return (
     <DialogPrimitive.Content
       data-vaul-drawer-direction={direction}
-      data-vaul-drawer-visible={visible ? 'true' : 'false'}
       vaul-drawer=""
+      vaul-drawer-visible={visible ? 'true' : 'false'}
       {...rest}
       ref={composedRef}
       style={

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -253,7 +253,7 @@ function Root({
 
       // We need to capture last time when drag with scroll was triggered and have a timeout between
       const absDraggedDistance = Math.abs(draggedDistance);
-      const wrapper = document.querySelector('[vaul-drawer-wrapper]');
+      const wrapper = document.querySelector('[data-vaul-drawer-wrapper]');
 
       // Calculate the percentage dragged, where 1 is the closed position
       let percentageDragged = absDraggedDistance / drawerHeightRef.current;
@@ -475,7 +475,7 @@ function Root({
 
   function resetDrawer() {
     if (!drawerRef.current) return;
-    const wrapper = document.querySelector('[vaul-drawer-wrapper]');
+    const wrapper = document.querySelector('[data-vaul-drawer-wrapper]');
     const currentSwipeAmount = getTranslate(drawerRef.current, direction);
 
     set(drawerRef.current, {
@@ -611,7 +611,7 @@ function Root({
   }, [visible]);
 
   function scaleBackground(open: boolean) {
-    const wrapper = document.querySelector('[vaul-drawer-wrapper]');
+    const wrapper = document.querySelector('[data-vaul-drawer-wrapper]');
 
     if (!wrapper || !shouldScaleBackground) return;
 
@@ -866,13 +866,13 @@ const Handle = React.forwardRef<HTMLDivElement, HandleProps>(function (
       }}
       // onPointerUp is already handled by the content component
       ref={ref}
-      vaul-drawer-visible={visible ? 'true' : 'false'}
-      vaul-handle=""
+      data-vaul-drawer-visible={visible ? 'true' : 'false'}
+      data-vaul-handle=""
       aria-hidden="true"
       {...rest}
     >
       {/* Expand handle's hit area beyond what's visible to ensure a 44x44 tap target for touch devices */}
-      <span vaul-handle-hitarea="" aria-hidden="true">
+      <span data-vaul-handle-hitarea="" aria-hidden="true">
         {children}
       </span>
     </div>
@@ -891,10 +891,10 @@ const Overlay = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<
       <DialogPrimitive.Overlay
         onMouseUp={onRelease}
         ref={composedRef}
-        vaul-drawer-visible={visible ? 'true' : 'false'}
-        vaul-overlay=""
-        vaul-snap-points={isOpen && hasSnapPoints ? 'true' : 'false'}
-        vaul-snap-points-overlay={isOpen && shouldFade ? 'true' : 'false'}
+        data-vaul-drawer-visible={visible ? 'true' : 'false'}
+        data-vaul-overlay=""
+        data-vaul-snap-points={isOpen && hasSnapPoints ? 'true' : 'false'}
+        data-vaul-snap-points-overlay={isOpen && shouldFade ? 'true' : 'false'}
         {...rest}
       />
     );
@@ -964,8 +964,8 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
   return (
     <DialogPrimitive.Content
       data-vaul-drawer-direction={direction}
-      vaul-drawer=""
-      vaul-drawer-visible={visible ? 'true' : 'false'}
+      data-vaul-drawer=""
+      data-vaul-drawer-visible={visible ? 'true' : 'false'}
       {...rest}
       ref={composedRef}
       style={

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -963,9 +963,9 @@ const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
 
   return (
     <DialogPrimitive.Content
+      data-vaul-drawer-direction={direction}
+      data-vaul-drawer-visible={visible ? 'true' : 'false'}
       vaul-drawer=""
-      vaul-drawer-direction={direction}
-      vaul-drawer-visible={visible ? 'true' : 'false'}
       {...rest}
       ref={composedRef}
       style={

--- a/src/style.css
+++ b/src/style.css
@@ -4,19 +4,19 @@
   transition: transform 0.5s cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-[vaul-drawer][vaul-drawer-direction='bottom'] {
+[vaul-drawer][data-vaul-drawer-direction='bottom'] {
   transform: translate3d(0, 100%, 0);
 }
 
-[vaul-drawer][vaul-drawer-direction='top'] {
+[vaul-drawer][data-vaul-drawer-direction='top'] {
   transform: translate3d(0, -100%, 0);
 }
 
-[vaul-drawer][vaul-drawer-direction='left'] {
+[vaul-drawer][data-vaul-drawer-direction='left'] {
   transform: translate3d(-100%, 0, 0);
 }
 
-[vaul-drawer][vaul-drawer-direction='right'] {
+[vaul-drawer][data-vaul-drawer-direction='right'] {
   transform: translate3d(100%, 0, 0);
 }
 
@@ -35,19 +35,19 @@
   overflow-x: hidden !important;
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][vaul-drawer-direction='top'] {
+[vaul-drawer][vaul-drawer-visible='true'][data-vaul-drawer-direction='top'] {
   transform: translate3d(0, var(--snap-point-height, 0), 0);
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][vaul-drawer-direction='bottom'] {
+[vaul-drawer][vaul-drawer-visible='true'][data-vaul-drawer-direction='bottom'] {
   transform: translate3d(0, var(--snap-point-height, 0), 0);
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][vaul-drawer-direction='left'] {
+[vaul-drawer][vaul-drawer-visible='true'][data-vaul-drawer-direction='left'] {
   transform: translate3d(var(--snap-point-height, 0), 0, 0);
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][vaul-drawer-direction='right'] {
+[vaul-drawer][vaul-drawer-visible='true'][data-vaul-drawer-direction='right'] {
   transform: translate3d(var(--snap-point-height, 0), 0, 0);
 }
 
@@ -67,7 +67,7 @@
   background-color: inherit;
 }
 
-[vaul-drawer][vaul-drawer-direction='top']::after {
+[vaul-drawer][data-vaul-drawer-direction='top']::after {
   top: initial;
   bottom: 100%;
   left: 0;
@@ -75,7 +75,7 @@
   height: 200%;
 }
 
-[vaul-drawer][vaul-drawer-direction='bottom']::after {
+[vaul-drawer][data-vaul-drawer-direction='bottom']::after {
   top: 100%;
   bottom: initial;
   left: 0;
@@ -83,7 +83,7 @@
   height: 200%;
 }
 
-[vaul-drawer][vaul-drawer-direction='left']::after {
+[vaul-drawer][data-vaul-drawer-direction='left']::after {
   left: initial;
   right: 100%;
   top: 0;
@@ -91,7 +91,7 @@
   width: 200%;
 }
 
-[vaul-drawer][vaul-drawer-direction='right']::after {
+[vaul-drawer][data-vaul-drawer-direction='right']::after {
   left: 100%;
   right: initial;
   top: 0;

--- a/src/style.css
+++ b/src/style.css
@@ -1,22 +1,22 @@
-[vaul-drawer] {
+[data-vaul-drawer] {
   touch-action: none;
   will-change: transform;
   transition: transform 0.5s cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-[vaul-drawer][data-vaul-drawer-direction='bottom'] {
+[data-vaul-drawer][data-vaul-drawer-direction='bottom'] {
   transform: translate3d(0, 100%, 0);
 }
 
-[vaul-drawer][data-vaul-drawer-direction='top'] {
+[data-vaul-drawer][data-vaul-drawer-direction='top'] {
   transform: translate3d(0, -100%, 0);
 }
 
-[vaul-drawer][data-vaul-drawer-direction='left'] {
+[data-vaul-drawer][data-vaul-drawer-direction='left'] {
   transform: translate3d(-100%, 0, 0);
 }
 
-[vaul-drawer][data-vaul-drawer-direction='right'] {
+[data-vaul-drawer][data-vaul-drawer-direction='right'] {
   transform: translate3d(100%, 0, 0);
 }
 
@@ -35,39 +35,39 @@
   overflow-x: hidden !important;
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][data-vaul-drawer-direction='top'] {
+[data-vaul-drawer][data-vaul-drawer-visible='true'][data-vaul-drawer-direction='top'] {
   transform: translate3d(0, var(--snap-point-height, 0), 0);
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][data-vaul-drawer-direction='bottom'] {
+[data-vaul-drawer][data-vaul-drawer-visible='true'][data-vaul-drawer-direction='bottom'] {
   transform: translate3d(0, var(--snap-point-height, 0), 0);
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][data-vaul-drawer-direction='left'] {
+[data-vaul-drawer][data-vaul-drawer-visible='true'][data-vaul-drawer-direction='left'] {
   transform: translate3d(var(--snap-point-height, 0), 0, 0);
 }
 
-[vaul-drawer][vaul-drawer-visible='true'][data-vaul-drawer-direction='right'] {
+[data-vaul-drawer][data-vaul-drawer-visible='true'][data-vaul-drawer-direction='right'] {
   transform: translate3d(var(--snap-point-height, 0), 0, 0);
 }
 
-[vaul-overlay] {
+[data-vaul-overlay] {
   opacity: 0;
   transition: opacity 0.5s cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-[vaul-overlay][vaul-drawer-visible='true'] {
+[data-vaul-overlay][data-vaul-drawer-visible='true'] {
   opacity: 1;
 }
 
-[vaul-drawer]::after {
+[data-vaul-drawer]::after {
   content: '';
   position: absolute;
   background: inherit;
   background-color: inherit;
 }
 
-[vaul-drawer][data-vaul-drawer-direction='top']::after {
+[data-vaul-drawer][data-vaul-drawer-direction='top']::after {
   top: initial;
   bottom: 100%;
   left: 0;
@@ -75,7 +75,7 @@
   height: 200%;
 }
 
-[vaul-drawer][data-vaul-drawer-direction='bottom']::after {
+[data-vaul-drawer][data-vaul-drawer-direction='bottom']::after {
   top: 100%;
   bottom: initial;
   left: 0;
@@ -83,7 +83,7 @@
   height: 200%;
 }
 
-[vaul-drawer][data-vaul-drawer-direction='left']::after {
+[data-vaul-drawer][data-vaul-drawer-direction='left']::after {
   left: initial;
   right: 100%;
   top: 0;
@@ -91,7 +91,7 @@
   width: 200%;
 }
 
-[vaul-drawer][data-vaul-drawer-direction='right']::after {
+[data-vaul-drawer][data-vaul-drawer-direction='right']::after {
   left: 100%;
   right: initial;
   top: 0;
@@ -99,7 +99,7 @@
   width: 200%;
 }
 
-[vaul-handle] {
+[data-vaul-handle] {
   display: block;
   position: relative;
   opacity: 0.8;
@@ -112,16 +112,16 @@
   cursor: grab;
 }
 
-[vaul-handle]:hover,
-[vaul-handle]:active {
+[data-vaul-handle]:hover,
+[data-vaul-handle]:active {
   opacity: 1;
 }
 
-[vaul-handle]:active {
+[data-vaul-handle]:active {
   cursor: grabbing;
 }
 
-[vaul-handle-hitarea] {
+[data-vaul-handle-hitarea] {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -131,11 +131,11 @@
   touch-action: inherit;
 }
 
-[vaul-overlay][vaul-snap-points='true']:not([vaul-snap-points-overlay='true']):not([data-state='closed']) {
+[data-vaul-overlay][data-vaul-snap-points='true']:not([data-vaul-snap-points-overlay='true']):not([data-state='closed']) {
   opacity: 0;
 }
 
-[vaul-overlay][vaul-snap-points-overlay='true']:not([vaul-drawer-visible='false']) {
+[data-vaul-overlay][data-vaul-snap-points-overlay='true']:not([data-vaul-drawer-visible='false']) {
   opacity: 1;
 }
 
@@ -148,13 +148,13 @@
 }
 
 @media (hover: hover) and (pointer: fine) {
-  [vaul-drawer] {
+  [data-vaul-drawer] {
     user-select: none;
   }
 }
 
 @media (pointer: fine) {
-  [vaul-handle-hitarea]: {
+  [data-vaul-handle-hitarea]: {
     width: 100%;
     height: 100%;
   }

--- a/src/style.css
+++ b/src/style.css
@@ -20,18 +20,18 @@
   transform: translate3d(100%, 0, 0);
 }
 
-.vaul-dragging .vaul-scrollable [vault-drawer-direction='top'] {
+.vaul-dragging .vaul-scrollable [data-vaul-drawer-direction='top'] {
   overflow-y: hidden !important;
 }
-.vaul-dragging .vaul-scrollable [vault-drawer-direction='bottom'] {
+.vaul-dragging .vaul-scrollable [data-vaul-drawer-direction='bottom'] {
   overflow-y: hidden !important;
 }
 
-.vaul-dragging .vaul-scrollable [vault-drawer-direction='left'] {
+.vaul-dragging .vaul-scrollable [data-vaul-drawer-direction='left'] {
   overflow-x: hidden !important;
 }
 
-.vaul-dragging .vaul-scrollable [vault-drawer-direction='right'] {
+.vaul-dragging .vaul-scrollable [data-vaul-drawer-direction='right'] {
   overflow-x: hidden !important;
 }
 

--- a/test/src/app/controlled/page.tsx
+++ b/test/src/app/controlled/page.tsx
@@ -8,7 +8,7 @@ export default function Page() {
   const [fullyControlled, setFullyControlled] = useState(false);
 
   return (
-    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" vaul-drawer-wrapper="">
+    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" data-vaul-drawer-wrapper="">
       <Drawer.Root open={open}>
         <Drawer.Trigger asChild onClick={() => setOpen(true)}>
           <button data-testid="trigger" className="text-2xl">

--- a/test/src/app/nested-drawers/page.tsx
+++ b/test/src/app/nested-drawers/page.tsx
@@ -4,7 +4,7 @@ import { Drawer } from 'vaul';
 
 export default function Page() {
   return (
-    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" vaul-drawer-wrapper="">
+    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" data-vaul-drawer-wrapper="">
       <Drawer.Root shouldScaleBackground>
         <Drawer.Trigger asChild>
           <button data-testid="trigger">Open Drawer</button>

--- a/test/src/app/non-dismissible/page.tsx
+++ b/test/src/app/non-dismissible/page.tsx
@@ -6,7 +6,7 @@ import { Drawer } from 'vaul';
 export default function Page() {
   const [open, setOpen] = useState(false);
   return (
-    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" vaul-drawer-wrapper="">
+    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" data-vaul-drawer-wrapper="">
       <Drawer.Root dismissible={false} open={open}>
         <Drawer.Trigger data-testid="trigger" asChild onClick={() => setOpen(true)}>
           <button>Open Drawer</button>

--- a/test/src/app/scrollable-with-inputs/page.tsx
+++ b/test/src/app/scrollable-with-inputs/page.tsx
@@ -4,7 +4,7 @@ import { Drawer } from 'vaul';
 
 export default function Page() {
   return (
-    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" vaul-drawer-wrapper="">
+    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" data-vaul-drawer-wrapper="">
       <Drawer.Root>
         <Drawer.Trigger asChild>
           <button>Open Drawer</button>

--- a/test/src/app/with-scaled-background/page.tsx
+++ b/test/src/app/with-scaled-background/page.tsx
@@ -68,7 +68,7 @@ export default function Page() {
   return (
     <div
       className="w-screen h-screen bg-white p-8 flex flex-col gap-2 justify-center items-center"
-      vaul-drawer-wrapper=""
+      data-vaul-drawer-wrapper=""
     >
       <select
         value={direction}

--- a/test/src/app/without-scaled-background/page.tsx
+++ b/test/src/app/without-scaled-background/page.tsx
@@ -6,7 +6,7 @@ import { Drawer } from 'vaul';
 export default function Page() {
   const [open, setOpen] = useState(false);
   return (
-    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" vaul-drawer-wrapper="">
+    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center" data-vaul-drawer-wrapper="">
       <Drawer.Root open={open} onOpenChange={setOpen}>
         <Drawer.Trigger asChild>
           <button data-testid="trigger" className="text-2xl">

--- a/test/tests/base.spec.ts
+++ b/test/tests/base.spec.ts
@@ -42,7 +42,7 @@ test.describe('Base tests', () => {
 
   test('should close when dragged down', async ({ page }) => {
     await openDrawer(page);
-    await page.hover('[vaul-drawer]');
+    await page.hover('[data-vaul-drawer]');
     await page.mouse.down();
     await page.mouse.move(0, 800);
     await page.mouse.up();
@@ -52,7 +52,7 @@ test.describe('Base tests', () => {
 
   test('should not close when dragged up', async ({ page }) => {
     await openDrawer(page);
-    await page.hover('[vaul-drawer]');
+    await page.hover('[data-vaul-drawer]');
     await page.mouse.down();
     await page.mouse.move(0, -800);
     await page.mouse.up();

--- a/test/tests/initial-snap.spec.ts
+++ b/test/tests/initial-snap.spec.ts
@@ -13,7 +13,7 @@ const snapPointYPositions = {
 } as const;
 
 const snapTo = async (page: Page, snapPointIndex: keyof typeof snapPointYPositions) => {
-  await page.hover('[vaul-drawer]');
+  await page.hover('[data-vaul-drawer]');
   await page.mouse.down();
   await page.mouse.move(0, snapPointYPositions[snapPointIndex]);
   await page.mouse.up();

--- a/test/tests/non-dismissible.spec.ts
+++ b/test/tests/non-dismissible.spec.ts
@@ -17,7 +17,7 @@ test.describe('Non-dismissible', () => {
 
   test('should not close when dragged down', async ({ page }) => {
     await openDrawer(page);
-    await page.hover('[vaul-drawer]');
+    await page.hover('[data-vaul-drawer]');
     await page.mouse.down();
     await page.mouse.move(0, 800);
     await page.mouse.up();

--- a/test/tests/with-scaled-background.spec.ts
+++ b/test/tests/with-scaled-background.spec.ts
@@ -7,26 +7,26 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('With scaled background', () => {
   test('should scale background', async ({ page }) => {
-    await expect(page.locator('[vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
+    await expect(page.locator('[data-vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
 
     await page.getByTestId('trigger').click();
 
-    await expect(page.locator('[vaul-drawer-wrapper]')).toHaveCSS('transform', /matrix/);
+    await expect(page.locator('[data-vaul-drawer-wrapper]')).toHaveCSS('transform', /matrix/);
   });
 
   test('should scale background when dragging', async ({ page }) => {
-    await expect(page.locator('[vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
+    await expect(page.locator('[data-vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
 
     await openDrawer(page);
 
-    await page.hover('[vaul-drawer]');
+    await page.hover('[data-vaul-drawer]');
     await page.mouse.down();
     await page.mouse.move(0, 100);
 
-    await expect(page.locator('[vaul-drawer-wrapper]')).toHaveCSS('transform', /matrix/);
+    await expect(page.locator('[data-vaul-drawer-wrapper]')).toHaveCSS('transform', /matrix/);
 
     await page.mouse.up();
 
-    await expect(page.locator('[vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
+    await expect(page.locator('[data-vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
   });
 });

--- a/test/tests/without-scaled-background.spec.ts
+++ b/test/tests/without-scaled-background.spec.ts
@@ -6,10 +6,10 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Without scaled background', () => {
   test('should not scale background', async ({ page }) => {
-    await expect(page.locator('[vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
+    await expect(page.locator('[data-vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
 
     await page.getByTestId('trigger').click();
 
-    await expect(page.locator('[vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
+    await expect(page.locator('[data-vaul-drawer-wrapper]')).not.toHaveCSS('transform', '');
   });
 });

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -11,7 +11,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className="antialiased text-gray-900 bg-gray-50">
-        <main vaul-drawer-wrapper="">{children}</main>
+        <main data-vaul-drawer-wrapper="">{children}</main>
         <Analytics />
       </body>
     </html>


### PR DESCRIPTION
Related issue: [369](https://github.com/emilkowalski/vaul/issues/369)

- This PR makes vaul use common data-attribute for content direction. This allows usage of Tailwind classes to style the Drawer differently for different directions.
- The typo `vault` is fixed in `style.css`