### PR TITLE
Contain CSS file in the published package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+# styles
+style.css

--- a/README.md
+++ b/README.md
@@ -144,3 +144,9 @@ The button that closes the dialog. [Props](https://www.radix-ui.com/docs/primiti
 ### Portal
 
 Portals your drawer into the body.
+
+### CSS File
+
+CSS in this library is inserted by JavaScript into `<head>` element by default. If you're having issue with it such as [CSP restriction](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src), you can use `vaul/style.css` CSS as a workaround to apply the styles.
+
+> Note: You don't need to import it unless the default inline styles is blocked by CSP.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "style.css"
   ],
   "exports": {
     "import": {
@@ -21,7 +22,7 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "build": "pnpm type-check && bunchee && pnpm copy-assets",
-    "copy-assets": "cp -r ./src/style.css ./dist/index.css",
+    "copy-assets": "cp -r ./src/style.css ./style.css",
     "dev": "bunchee --watch",
     "dev:website": "turbo run dev --filter=website...",
     "dev:test": "turbo run dev --filter=test...",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "scripts": {
     "type-check": "tsc --noEmit",
-    "build": "pnpm type-check && bunchee",
+    "build": "pnpm type-check && bunchee && pnpm copy-assets",
+    "copy-assets": "cp -r ./src/style.css ./dist/index.css",
     "dev": "bunchee --watch",
     "dev:website": "turbo run dev --filter=website...",
     "dev:test": "turbo run dev --filter=test...",


### PR DESCRIPTION
The css file was output by tsup into the `dist/` before, this PR manually copy the css into `./style.css` since there're users relying on it already.

Updated the readme to clarify the usage. This could be a workaround solution for users having CSP restrictions

Closes #283
Closes #357 
