### PR TITLE
fix: Fix non-modal drawers without overlay to properly set body pointer events

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -646,6 +646,17 @@ export function Root({
     }
   }
 
+  React.useEffect(() => {
+    if (!modal) {
+      // Need to do this manually unfortunately
+      if (typeof window !== 'undefined') {
+        window.requestAnimationFrame(() => {
+          document.body.style.pointerEvents = 'auto';
+        });
+      }
+    }
+  }, [modal]);
+
   return (
     <DialogPrimitive.Root
       defaultOpen={defaultOpen}
@@ -706,13 +717,6 @@ export const Overlay = React.forwardRef<HTMLDivElement, React.ComponentPropsWith
 
     // Overlay is the component that is locking scroll, removing it will unlock the scroll without having to dig into Radix's Dialog library
     if (!modal) {
-      // Need to do this manually unfortunately
-      if (typeof window !== 'undefined') {
-        window.requestAnimationFrame(() => {
-          document.body.style.pointerEvents = 'auto';
-        });
-      }
-	  
       return null;
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -649,11 +649,9 @@ export function Root({
   React.useEffect(() => {
     if (!modal) {
       // Need to do this manually unfortunately
-      if (typeof window !== 'undefined') {
-        window.requestAnimationFrame(() => {
-          document.body.style.pointerEvents = 'auto';
-        });
-      }
+      window.requestAnimationFrame(() => {
+        document.body.style.pointerEvents = 'auto';
+      });
     }
   }, [modal]);
 


### PR DESCRIPTION
This fixes issue when `Drawer` without `Drawer.Overlay` while having `modal={false}`
This fix should also not break when `Drawer.Overlay` is passed

Without `Drawer.Overlay`
```tsx
<Drawer.Root modal={false}>
  <Drawer.Trigger>Open</Drawer.Trigger>
  <Drawer.Portal>
    <Drawer.Content>
      <p>Content</p>
    </Drawer.Content>
  </Drawer.Portal>
</Drawer.Root>
```

With `Drawer.Overlay`
```tsx
<Drawer.Root modal={false}>
  <Drawer.Trigger>Open</Drawer.Trigger>
  <Drawer.Portal>
    <Drawer.Content>
      <p>Content</p>
    </Drawer.Content>
    <Drawer.Overlay />
  </Drawer.Portal>
</Drawer.Root>
```