### PR TITLE
fix: restore position settings on drawer unmount

### DIFF
--- a/src/use-position-fixed.ts
+++ b/src/use-position-fixed.ts
@@ -110,6 +110,20 @@ export function usePositionFixed({
   }, []);
 
   React.useEffect(() => {
+    if (!modal) return;
+
+    return () => {
+      if (typeof document === 'undefined') return;
+
+      // Another drawer is opened, safe to ignore the execution
+      const hasDrawerOpened = !!document.querySelector('[data-vaul-drawer]');
+      if (hasDrawerOpened) return;
+
+      restorePositionSetting();
+    };
+  }, [modal, restorePositionSetting]);
+
+  React.useEffect(() => {
     if (nested || !hasBeenOpened) return;
     // This is needed to force Safari toolbar to show **before** the drawer starts animating to prevent a gnarly shift from happening
     if (isOpen) {

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -14,7 +14,8 @@ export default function Page() {
       <Link href="/non-dismissible">Non-dismissible</Link>
       <Link href="/initial-snap">Initial snap</Link>
       <Link href="/controlled">Controlled</Link>
-      <Link href="/default-open">Controlled</Link>
+      <Link href="/default-open">Default open</Link>
+      <Link href="/with-redirect">With redirect</Link>
     </div>
   );
 }

--- a/test/src/app/with-redirect/long-page/page.tsx
+++ b/test/src/app/with-redirect/long-page/page.tsx
@@ -3,7 +3,7 @@
 export default function Page() {
   return (
     <div className="bg-zinc-100 space-y-10">
-      <p data-hover className="pb-[120vh] bg-zinc-600 text-white font-bold">scroll down</p>
+      <p className="pb-[120vh] bg-zinc-600 text-white font-bold">scroll down</p>
       <p data-testid="content" className="py-32 bg-zinc-800 text-white">content only visible after scroll</p>
     </div>
   );

--- a/test/src/app/with-redirect/long-page/page.tsx
+++ b/test/src/app/with-redirect/long-page/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+export default function Page() {
+  return (
+    <div className="bg-zinc-100 space-y-10">
+      <p data-hover className="pb-[120vh] bg-zinc-600 text-white font-bold">scroll down</p>
+      <p data-testid="content" className="py-32 bg-zinc-800 text-white">content only visible after scroll</p>
+    </div>
+  );
+}

--- a/test/src/app/with-redirect/page.tsx
+++ b/test/src/app/with-redirect/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Link from 'next/link';
+import { Drawer } from 'vaul';
+
+export default function Page() {
+  return (
+    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center">
+      <Drawer.Root>
+        <Drawer.Trigger asChild>
+          <button data-testid="trigger" className="text-2xl">
+            Open Drawer
+          </button>
+        </Drawer.Trigger>
+        <Drawer.Portal>
+          <Drawer.Overlay data-testid="overlay" className="fixed inset-0 bg-black/40" />
+          <Drawer.Content
+            data-testid="content"
+            className="bg-zinc-100 flex flex-col rounded-t-[10px] h-[96%] mt-24 fixed bottom-0 left-0 right-0"
+          >
+            <Drawer.Close data-testid="drawer-close">Close</Drawer.Close>
+            <div className="p-4 bg-white rounded-t-[10px] flex-1">
+              <div className="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-zinc-300 mb-8" />
+              <div className="max-w-md mx-auto">
+                <Drawer.Title className="font-medium mb-4">Redirect to another route.</Drawer.Title>
+                <p className="text-zinc-600 mb-2">This route is only used to test the body reset position.</p>
+                <p className="text-zinc-600 mb-8">
+                  Go to{' '}
+                  <Link href="/with-redirect/long-page" data-testid="link" className="underline">
+                    another route
+                  </Link>{' '}
+                </p>
+              </div>
+            </div>
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer.Root>
+    </div>
+  );
+}

--- a/test/tests/with-redirect.spec.ts
+++ b/test/tests/with-redirect.spec.ts
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/with-redirect');
 });
 
-test.describe('Without redirect', () => {
+test.describe('With redirect', () => {
   test('should restore body position settings', async ({ page }) => {
     await openDrawer(page);
     await page.getByTestId('link').click();
@@ -19,7 +19,7 @@ test.describe('Without redirect', () => {
     await expect(content).toBeVisible();
 
     content.scrollIntoViewIfNeeded();
-    
+
     await expect(page.getByTestId('content')).toBeInViewport();
   });
 });

--- a/test/tests/with-redirect.spec.ts
+++ b/test/tests/with-redirect.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { openDrawer } from './helpers';
+import { ANIMATION_DURATION } from './constants';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/with-redirect');
+});
+
+test.describe('Without redirect', () => {
+  test('should restore body position settings', async ({ page }) => {
+    await openDrawer(page);
+    await page.getByTestId('link').click();
+
+    await page.waitForURL('**/with-redirect/long-page');
+
+    const content = page.getByTestId('content');
+
+    // safe check
+    await expect(content).toBeVisible();
+
+    content.scrollIntoViewIfNeeded();
+    
+    await expect(page.getByTestId('content')).toBeInViewport();
+  });
+});

--- a/test/tests/with-redirect.spec.ts
+++ b/test/tests/with-redirect.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import { openDrawer } from './helpers';
-import { ANIMATION_DURATION } from './constants';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/with-redirect');


### PR DESCRIPTION
In previous versions (~0.9.2) the restore position settings was executed in the useEffect unmount trigger: https://github.com/emilkowalski/vaul/blob/3510ebdfc35a67a6c7ec8ea66386dbaf0e1b941e/src/index.tsx#L347-L352

The new version is going to only restore based on the `onChange`, which is fine and works better for most of the situations, **but** it fails to restore during a redirect/click in a link inside of the drawer.
https://github.com/emilkowalski/vaul/blob/5cd388cfb5d9bf1664d27fc280839562dd79297c/src/index.tsx#L172-L176

Added a new playright example:
![image](https://github.com/user-attachments/assets/88f2ef42-5226-4bad-b480-a415af2a0da1)

It only affects iphone, after redirect the body is going to still have the position fixed, preventing any scroll:
![image](https://github.com/user-attachments/assets/ecf1376c-4d21-4ab9-ab85-c6b27927c37c)

![image](https://github.com/user-attachments/assets/0e98e396-f5d0-489a-8ea3-73f195fcda93)


I added a new solution trying to improve the unmount trigger, no changes to the `onChange` flow, but during the unmount if there is no drawer in the dom, then it restores covering the no-trigger of `onChange` , and it doesn't mess up nested drawers because of the dom check. I'm still thinking if it would be better/safer to add a setTimeout to wait any animation... during my tests the current logic was enough.

Playright final result:
![image](https://github.com/user-attachments/assets/ba14ca29-c7fd-4302-9e99-898b67be430f)

