### PR TITLE
Fix: Ensure drawer opens at the specified active snap point on initial render

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -16,6 +16,7 @@ interface DrawerContextValue {
   keyboardIsOpen: React.MutableRefObject<boolean>;
   snapPointsOffset: number[] | null;
   snapPoints?: (number | string)[] | null;
+  activeSnapPointIndex?: number;
   modal: boolean;
   shouldFade: boolean;
   activeSnapPoint?: number | string | null;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -819,6 +819,7 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
     onDrag,
     keyboardIsOpen,
     snapPointsOffset,
+    activeSnapPointIndex,
     modal,
     isOpen,
     direction,
@@ -886,7 +887,7 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
       style={
         snapPointsOffset && snapPointsOffset.length > 0
           ? ({
-              '--snap-point-height': `${snapPointsOffset[0]!}px`,
+              '--snap-point-height': `${snapPointsOffset[activeSnapPointIndex]}px`,
               ...style,
             } as React.CSSProperties)
           : style

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -887,7 +887,7 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
       style={
         snapPointsOffset && snapPointsOffset.length > 0
           ? ({
-              '--snap-point-height': `${snapPointsOffset[activeSnapPointIndex]}px`,
+              '--snap-point-height': `${snapPointsOffset[activeSnapPointIndex ?? 0]!}px`,
               ...style,
             } as React.CSSProperties)
           : style

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,8 +25,8 @@ import { usePositionFixed } from './use-position-fixed';
 
 export interface WithFadeFromProps {
   /**
-   * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up. 
-   * Should go from least visible. Example `[0.2, 0.5, 0.8]`. 
+   * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up.
+   * Should go from least visible. Example `[0.2, 0.5, 0.8]`.
    * You can also use px values, which doesn't take screen height into account.
    */
   snapPoints: (number | string)[];
@@ -38,8 +38,8 @@ export interface WithFadeFromProps {
 
 export interface WithoutFadeFromProps {
   /**
-   * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up. 
-   * Should go from least visible. Example `[0.2, 0.5, 0.8]`. 
+   * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up.
+   * Should go from least visible. Example `[0.2, 0.5, 0.8]`.
    * You can also use px values, which doesn't take screen height into account.
    */
   snapPoints?: (number | string)[];
@@ -52,7 +52,7 @@ export type DialogProps = {
   children?: React.ReactNode;
   open?: boolean;
   /**
-   * Number between 0 and 1 that determines when the drawer should be closed. 
+   * Number between 0 and 1 that determines when the drawer should be closed.
    * Example: threshold of 0.5 would close the drawer if the user swiped for 50% of the height of the drawer or more.
    * @default 0.25
    */
@@ -64,12 +64,12 @@ export type DialogProps = {
   onOpenChange?: (open: boolean) => void;
   shouldScaleBackground?: boolean;
   /**
-   * When `false` we don't change body's background color when the drawer is open. 
+   * When `false` we don't change body's background color when the drawer is open.
    * @default true
    */
   setBackgroundColorOnScale?: boolean;
   /**
-   * Duration for which the drawer is not draggable after scrolling content inside of the drawer. 
+   * Duration for which the drawer is not draggable after scrolling content inside of the drawer.
    * @default 500ms
    */
   scrollLockTimeout?: number;
@@ -78,12 +78,12 @@ export type DialogProps = {
    */
   fixed?: boolean;
   /**
-   * When `true` only allows the drawer to be dragged by the `<Drawer.Handle />` component. 
+   * When `true` only allows the drawer to be dragged by the `<Drawer.Handle />` component.
    * @default false
    */
   handleOnly?: boolean;
   /**
-   * When `false` dragging, clicking outside, pressing esc, etc. will not close the drawer. 
+   * When `false` dragging, clicking outside, pressing esc, etc. will not close the drawer.
    * Use this in comination with the `open` prop, otherwise you won't be able to open/close the drawer.
    * @default true
    */
@@ -91,14 +91,14 @@ export type DialogProps = {
   onDrag?: (event: React.PointerEvent<HTMLDivElement>, percentageDragged: number) => void;
   onRelease?: (event: React.PointerEvent<HTMLDivElement>, open: boolean) => void;
   /**
-   * When `false` it allows to interact with elements outside of the drawer without closing it. 
+   * When `false` it allows to interact with elements outside of the drawer without closing it.
    * @default true
    */
   modal?: boolean;
   nested?: boolean;
   onClose?: () => void;
   /**
-   * Direction of the drawer. Can be `top` or `bottom`, `left`, `right`. 
+   * Direction of the drawer. Can be `top` or `bottom`, `left`, `right`.
    * @default 'bottom'
    */
   direction?: 'top' | 'bottom' | 'left' | 'right';
@@ -113,21 +113,21 @@ export type DialogProps = {
    */
   disablePreventScroll?: boolean;
   /**
-   * When `true` Vaul will reposition inputs rather than scroll then into view if the keyboard is in the way. 
+   * When `true` Vaul will reposition inputs rather than scroll then into view if the keyboard is in the way.
    * Setting it to `false` will fall back to the default browser behavior.
    * @default true when {@link snapPoints} is defined
    */
   repositionInputs?: boolean;
   /**
-   * Disabled velocity based swiping for snap points. 
-   * This means that a snap point won't be skipped even if the velocity is high enough. 
+   * Disabled velocity based swiping for snap points.
+   * This means that a snap point won't be skipped even if the velocity is high enough.
    * Useful if each snap point in a drawer is equally important.
    * @default false
    */
   snapToSequentialPoint?: boolean;
   container?: HTMLElement | null;
   /**
-   * Gets triggered after the open or close animation ends, it receives an `open` argument with the `open` state of the drawer by the time the function was triggered. 
+   * Gets triggered after the open or close animation ends, it receives an `open` argument with the `open` state of the drawer by the time the function was triggered.
    * Useful to revert any state changes for example.
    */
   onAnimationEnd?: (open: boolean) => void;
@@ -765,6 +765,7 @@ export function Root({
           keyboardIsOpen,
           modal,
           snapPointsOffset,
+          activeSnapPointIndex,
           direction,
           shouldScaleBackground,
           setBackgroundColorOnScale,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -127,8 +127,8 @@ export type DialogProps = {
   snapToSequentialPoint?: boolean;
   container?: HTMLElement | null;
   /**
-   * Gets triggered after the open or close animation ends, it receives an `open` argument with the `open` state of the drawer by the time the function was triggered.
-   * Useful to revert any state changes for example. 
+   * Gets triggered after the open or close animation ends, it receives an `open` argument with the `open` state of the drawer by the time the function was triggered. 
+   * Useful to revert any state changes for example.
    */
   onAnimationEnd?: (open: boolean) => void;
   preventScrollRestoration?: boolean;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,8 +25,8 @@ import { usePositionFixed } from './use-position-fixed';
 
 export interface WithFadeFromProps {
   /**
-   * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up.
-   * Should go from least visible. Example `[0.2, 0.5, 0.8]`.
+   * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up. 
+   * Should go from least visible. Example `[0.2, 0.5, 0.8]`. 
    * You can also use px values, which doesn't take screen height into account.
    */
   snapPoints: (number | string)[];
@@ -38,8 +38,8 @@ export interface WithFadeFromProps {
 
 export interface WithoutFadeFromProps {
   /**
-   * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up.
-   * Should go from least visible. Example `[0.2, 0.5, 0.8]`.
+   * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up. 
+   * Should go from least visible. Example `[0.2, 0.5, 0.8]`. 
    * You can also use px values, which doesn't take screen height into account.
    */
   snapPoints?: (number | string)[];
@@ -52,7 +52,7 @@ export type DialogProps = {
   children?: React.ReactNode;
   open?: boolean;
   /**
-   * Number between 0 and 1 that determines when the drawer should be closed.
+   * Number between 0 and 1 that determines when the drawer should be closed. 
    * Example: threshold of 0.5 would close the drawer if the user swiped for 50% of the height of the drawer or more.
    * @default 0.25
    */
@@ -64,12 +64,12 @@ export type DialogProps = {
   onOpenChange?: (open: boolean) => void;
   shouldScaleBackground?: boolean;
   /**
-   * When `false` we don't change body's background color when the drawer is open.
+   * When `false` we don't change body's background color when the drawer is open. 
    * @default true
    */
   setBackgroundColorOnScale?: boolean;
   /**
-   * Duration for which the drawer is not draggable after scrolling content inside of the drawer.
+   * Duration for which the drawer is not draggable after scrolling content inside of the drawer. 
    * @default 500ms
    */
   scrollLockTimeout?: number;
@@ -78,12 +78,12 @@ export type DialogProps = {
    */
   fixed?: boolean;
   /**
-   * When `true` only allows the drawer to be dragged by the `<Drawer.Handle />` component.
+   * When `true` only allows the drawer to be dragged by the `<Drawer.Handle />` component. 
    * @default false
    */
   handleOnly?: boolean;
   /**
-   * When `false` dragging, clicking outside, pressing esc, etc. will not close the drawer.
+   * When `false` dragging, clicking outside, pressing esc, etc. will not close the drawer. 
    * Use this in comination with the `open` prop, otherwise you won't be able to open/close the drawer.
    * @default true
    */
@@ -91,14 +91,14 @@ export type DialogProps = {
   onDrag?: (event: React.PointerEvent<HTMLDivElement>, percentageDragged: number) => void;
   onRelease?: (event: React.PointerEvent<HTMLDivElement>, open: boolean) => void;
   /**
-   * When `false` it allows to interact with elements outside of the drawer without closing it.
+   * When `false` it allows to interact with elements outside of the drawer without closing it. 
    * @default true
    */
   modal?: boolean;
   nested?: boolean;
   onClose?: () => void;
   /**
-   * Direction of the drawer. Can be `top` or `bottom`, `left`, `right`.
+   * Direction of the drawer. Can be `top` or `bottom`, `left`, `right`. 
    * @default 'bottom'
    */
   direction?: 'top' | 'bottom' | 'left' | 'right';
@@ -113,14 +113,14 @@ export type DialogProps = {
    */
   disablePreventScroll?: boolean;
   /**
-   * When `true` Vaul will reposition inputs rather than scroll then into view if the keyboard is in the way.
+   * When `true` Vaul will reposition inputs rather than scroll then into view if the keyboard is in the way. 
    * Setting it to `false` will fall back to the default browser behavior.
    * @default true when {@link snapPoints} is defined
    */
   repositionInputs?: boolean;
   /**
-   * Disabled velocity based swiping for snap points.
-   * This means that a snap point won't be skipped even if the velocity is high enough.
+   * Disabled velocity based swiping for snap points. 
+   * This means that a snap point won't be skipped even if the velocity is high enough. 
    * Useful if each snap point in a drawer is equally important.
    * @default false
    */
@@ -128,7 +128,7 @@ export type DialogProps = {
   container?: HTMLElement | null;
   /**
    * Gets triggered after the open or close animation ends, it receives an `open` argument with the `open` state of the drawer by the time the function was triggered.
-   * Useful to revert any state changes for example.
+   * Useful to revert any state changes for example. 
    */
   onAnimationEnd?: (open: boolean) => void;
   preventScrollRestoration?: boolean;


### PR DESCRIPTION
### Issue: Drawer Initializes at First Snap Point Regardless of activeSnapPoint Setting

When setting `activeSnapPoint `to any value other than the first element in the `snapPoints `array, the drawer component always initializes at the first snap point on the initial render. It only updates to the correct `activeSnapPoint `after an external re-render occurs. This behavior is due to how the initial style is assigned and how `snapPointsOffset `is calculated when the component first mounts. 

This can be recreated by running the repo localy, and try to use `/initial-snap` test route. This does not work of the bat (it will open drawer with offset for the first element in the `snapPoints `array), but opening `initial-snap/page.tsx`, and saving any change, will force a re-render which will then open the drawer at the correct snap point.

#### Current Behavior:

The `DialogPrimitive.Content` component assigns the CSS custom property `--snap-point-heigh`t to `snapPointsOffset[0]`, which corresponds to the first snap point.

https://github.com/emilkowalski/vaul/blob/1142f66e22f65c74d6f8a0068df1dfa809f1c356/src/index.tsx#L885-L892

#### Proposed Change in PR:

In this PR, I changed the initialization of `--snap-point-height` to use `activeSnapPointIndex `instead of always defaulting to the first element. This ensures that the drawer starts at the correct snap point specified by `activeSnapPoint `without requiring a re-render.