### PR TITLE
fix: nested drawer onOpenChange issue

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1102,12 +1102,6 @@ export function NestedRoot({ onDrag, onOpenChange, open: nestedIsOpen, ...rest }
     throw new Error('Drawer.NestedRoot must be placed in another drawer');
   }
 
-  React.useEffect(() => {
-    setTimeout(() => {
-      onNestedOpenChange(!!nestedIsOpen);
-    }, TRANSITIONS.DURATION * 1000 + 50);
-  }, [nestedIsOpen]);
-
   return (
     <Root
       nested

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -688,7 +688,9 @@ export function Root({
 
     set(drawerRef.current, {
       transition: `transform ${TRANSITIONS.DURATION}s cubic-bezier(${TRANSITIONS.EASE.join(',')})`,
-      transform: isVertical(direction) ? `scale(${scale}) translate3d(0, ${initialTranslate}px, 0)` : `scale(${scale}) translate3d(${initialTranslate}, 0, 0)`,
+      transform: isVertical(direction)
+        ? `scale(${scale}) translate3d(0, ${initialTranslate}px, 0)`
+        : `scale(${scale}) translate3d(${initialTranslate}px, 0, 0)`,
     });
 
     if (!o && drawerRef.current) {
@@ -1093,16 +1095,23 @@ export const Handle = React.forwardRef<HTMLDivElement, HandleProps>(function (
 
 Handle.displayName = 'Drawer.Handle';
 
-export function NestedRoot({ onDrag, onOpenChange, ...rest }: DialogProps) {
+export function NestedRoot({ onDrag, onOpenChange, open: nestedIsOpen, ...rest }: DialogProps) {
   const { onNestedDrag, onNestedOpenChange, onNestedRelease } = useDrawerContext();
 
   if (!onNestedDrag) {
     throw new Error('Drawer.NestedRoot must be placed in another drawer');
   }
 
+  React.useEffect(() => {
+    setTimeout(() => {
+      onNestedOpenChange(!!nestedIsOpen);
+    }, TRANSITIONS.DURATION * 1000 + 50);
+  }, [nestedIsOpen]);
+
   return (
     <Root
       nested
+      open={nestedIsOpen}
       onClose={() => {
         onNestedOpenChange(false);
       }}
@@ -1114,6 +1123,7 @@ export function NestedRoot({ onDrag, onOpenChange, ...rest }: DialogProps) {
         if (o) {
           onNestedOpenChange(o);
         }
+        onOpenChange?.(o);
       }}
       onRelease={onNestedRelease}
       {...rest}


### PR DESCRIPTION
This appears to fix the open issue
[Nested drawer doesn't fire onOpenChange callback #457](https://github.com/emilkowalski/vaul/issues/457)

And also allows for the nested drawer to be controlled independently via `nestedIsOpen`

I noticed that the onOpenChange got removed in this commit
https://github.com/emilkowalski/vaul/compare/v0.9.2...v0.9.4#diff-0b5adbfe7b36e4ae2f479291e20152e33e940f7f265162d77f40f6bdb5da7405L1071

For my use case I also needed to open a nested drawer on route change, I've attached a short video to illustrate what I mean.


https://github.com/user-attachments/assets/82d9b87f-18bd-4617-94dc-369b80256efe

For info: to ensure that the parent drawer transitions correctly when the nested drawer is opened on route change I also needed to add this code

```js
  React.useEffect(() => {
    setTimeout(() => {
      onNestedOpenChange(!!nestedIsOpen);
    }, TRANSITIONS.DURATION * 1000 + 50);
  }, [nestedIsOpen]);
  ```

Maybe there is a cleaner way, but it seems to work.

Thought this fix might be useful to others.