### PR TITLE
fix: remove colon from styles

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -174,7 +174,7 @@
 }
 
 @media (pointer: fine) {
-  [data-vaul-handle-hitarea]: {
+  [data-vaul-handle-hitarea] {
     width: 100%;
     height: 100%;
   }


### PR DESCRIPTION
seems like a `:` snuck into `src/style.css`
