### PR TITLE
Remove incorrect colon from style.css

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -174,7 +174,7 @@
 }
 
 @media (pointer: fine) {
-  [data-vaul-handle-hitarea]: {
+  [data-vaul-handle-hitarea] {
     width: 100%;
     height: 100%;
   }


### PR DESCRIPTION
There is a colon after the `data-vaul-handle-hitarea` selector that shouldn't be there.

It will throw warnings when bundling the css file using Vite:

`warnings when minifying css:
▲ [WARNING] Expected identifier but found whitespace [css-syntax-error]`

This PR removes the colon.