### PR TITLE
Explicitly specify CSS export

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,19 @@
     "style.css"
   ],
   "exports": {
-    "import": {
-      "types": "./dist/index.d.mts",
-      "default": "./dist/index.mjs"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
-    "require": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+    "./style.css": {
+      "import": "./style.css",
+      "require": "./style.css"
     }
   },
   "scripts": {


### PR DESCRIPTION
Resolves https://github.com/emilkowalski/vaul/issues/465

Explicitly specifies CSS export, inspired by https://github.com/vitejs/vite/discussions/2657#discussioncomment-5856909

## Usage in Remix

```tsx
// app/root.tsx
import type { LinksFunction } from "@remix-run/node";
import vaulStyles from "vaul/style.css?url";

export const links: LinksFunction = () => [
  { rel: "stylesheet", href: vaulStyles },
];
```