### PR TITLE
feat: Add support for new `<Drawer.SnapPoint />`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ export interface WithFadeFromProps {
    * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up.
    * Should go from least visible. Example `[0.2, 0.5, 0.8]`.
    * You can also use px values, which doesn't take screen height into account.
+   * Should <Drawer.SnapPoint /> be used, this prop will be ignored.
    */
   snapPoints: (number | string)[];
   /**
@@ -42,6 +43,7 @@ export interface WithoutFadeFromProps {
    * Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up.
    * Should go from least visible. Example `[0.2, 0.5, 0.8]`.
    * You can also use px values, which doesn't take screen height into account.
+   * Should <Drawer.SnapPoint /> be used, this prop will be ignored.
    */
   snapPoints?: (number | string)[];
   fadeFromIndex?: never;
@@ -142,14 +144,14 @@ export function Root({
   children,
   onDrag: onDragProp,
   onRelease: onReleaseProp,
-  snapPoints,
+  snapPoints: initialSnapPoints,
   shouldScaleBackground = false,
   setBackgroundColorOnScale = true,
   closeThreshold = CLOSE_THRESHOLD,
   scrollLockTimeout = SCROLL_LOCK_TIMEOUT,
   dismissible = true,
   handleOnly = false,
-  fadeFromIndex = snapPoints && snapPoints.length - 1,
+  fadeFromIndex: initialFadeFromIndex,
   activeSnapPoint: activeSnapPointProp,
   setActiveSnapPoint: setActiveSnapPointProp,
   fixed,
@@ -167,6 +169,12 @@ export function Root({
   container,
   autoFocus = false,
 }: DialogProps) {
+  const [snapPoints, setSnapPoints] = React.useState<(string | number)[] | undefined>(
+    // If no snap points are provided, default to [0, 1] until we can ensure no snap points are present in DOM
+    initialSnapPoints ?? [0, 1],
+  );
+  const fadeFromIndex = initialFadeFromIndex ?? (snapPoints && snapPoints.length - 1);
+
   const [isOpen = false, setIsOpen] = useControllableState({
     defaultProp: defaultOpen,
     prop: openProp,
@@ -214,10 +222,13 @@ export function Root({
   const drawerWidthRef = React.useRef(drawerRef.current?.getBoundingClientRect().width || 0);
   const initialDrawerHeight = React.useRef(0);
 
-  const onSnapPointChange = React.useCallback((activeSnapPointIndex: number) => {
-    // Change openTime ref when we reach the last snap point to prevent dragging for 500ms incase it's scrollable.
-    if (snapPoints && activeSnapPointIndex === snapPointsOffset.length - 1) openTime.current = new Date();
-  }, []);
+  const onSnapPointChange = React.useCallback(
+    (activeSnapPointIndex: number) => {
+      // Change openTime ref when we reach the last snap point to prevent dragging for 500ms incase it's scrollable.
+      if (snapPoints && activeSnapPointIndex === snapPointsOffset.length - 1) openTime.current = new Date();
+    },
+    [snapPoints],
+  );
 
   const {
     activeSnapPoint,
@@ -477,6 +488,8 @@ export function Root({
     function onVisualViewportChange() {
       if (!drawerRef.current || !repositionInputs) return;
 
+      updateSnapPoints();
+
       const focusedElement = document.activeElement as HTMLElement;
       if (isInput(focusedElement) || keyboardIsOpen.current) {
         const visualViewportHeight = window.visualViewport?.height || 0;
@@ -661,6 +674,35 @@ export function Root({
     onReleaseProp?.(event, true);
     resetDrawer();
   }
+
+  function updateSnapPoints() {
+    if (!drawerRef.current) return;
+    const drawerPosition = drawerRef.current?.getBoundingClientRect().y ?? 0;
+    const snapPointsNodes = document.querySelectorAll('[data-vaul-snap-point]');
+    if (snapPointsNodes.length === 0) return;
+    const newSnapPoints = Array.from(snapPointsNodes).map((snapPoint) => {
+      const snapPointOffset = Number(snapPoint.getAttribute('data-vaul-offset')) ?? 0;
+      const snapPointVerticalPosition = snapPoint.getBoundingClientRect().y;
+      return `${snapPointVerticalPosition + WINDOW_TOP_OFFSET + snapPointOffset - drawerPosition}px`;
+    });
+    setSnapPoints(newSnapPoints);
+
+    return newSnapPoints;
+  }
+
+  React.useEffect(() => {
+    if (isOpen) {
+      // Detect if any snapPoints are present in DOM, otherwise set snapPoints to undefined
+      window.requestAnimationFrame(() => {
+        const newSnapPoints = updateSnapPoints();
+        if (newSnapPoints) {
+          setActiveSnapPoint(newSnapPoints[0]);
+        } else if (!initialSnapPoints || initialSnapPoints.length === 0) {
+          setSnapPoints(undefined);
+        }
+      });
+    }
+  }, [isOpen]);
 
   React.useEffect(() => {
     // Trigger enter animation without using CSS animation
@@ -1095,6 +1137,16 @@ export const Handle = React.forwardRef<HTMLDivElement, HandleProps>(function (
 
 Handle.displayName = 'Drawer.Handle';
 
+export type SnapPointProps = {
+  offset?: number;
+};
+
+export const SnapPoint = React.forwardRef<HTMLAnchorElement, SnapPointProps>(function ({ offset = 0 }, ref) {
+  return <a ref={ref} data-vaul-snap-point data-vaul-offset={offset} />;
+});
+
+SnapPoint.displayName = 'Drawer.SnapPoint';
+
 export function NestedRoot({ onDrag, onOpenChange, open: nestedIsOpen, ...rest }: DialogProps) {
   const { onNestedDrag, onNestedOpenChange, onNestedRelease } = useDrawerContext();
 
@@ -1145,4 +1197,5 @@ export const Drawer = {
   Close: DialogPrimitive.Close,
   Title: DialogPrimitive.Title,
   Description: DialogPrimitive.Description,
+  SnapPoint,
 };

--- a/test/src/app/page.tsx
+++ b/test/src/app/page.tsx
@@ -8,6 +8,7 @@ export default function Page() {
       <Link href="/with-scaled-background">With scaled background</Link>
       <Link href="/without-scaled-background">Without scaled background</Link>
       <Link href="/with-snap-points">With snap points</Link>
+      <Link href="/with-embedded-snap-points">With embedded snap points</Link>
       <Link href="/with-modal-false">With modal false</Link>
       <Link href="/scrollable-with-inputs">Scrollable with inputs</Link>
       <Link href="/nested-drawers">Nested drawers</Link>

--- a/test/src/app/with-embedded-snap-points/page.tsx
+++ b/test/src/app/with-embedded-snap-points/page.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { clsx } from 'clsx';
+import { useState } from 'react';
+import { Drawer } from 'vaul';
+
+export default function Page() {
+  const [snap, setSnap] = useState<number | string | null>();
+
+  return (
+    <div className="w-screen h-screen bg-white p-8 flex justify-center items-center">
+      <Drawer.Root snapPoints={(snapPoints) => [...snapPoints, 1]} activeSnapPoint={snap} setActiveSnapPoint={setSnap}>
+        <Drawer.Trigger asChild>
+          <button data-testid="trigger">Open Drawer</button>
+        </Drawer.Trigger>
+        <Drawer.Overlay className="fixed inset-0 bg-black/40" />
+        <Drawer.Portal>
+          <Drawer.Content
+            data-testid="content"
+            className="fixed flex flex-col bg-white border border-gray-200 border-b-none rounded-t-[10px] bottom-0 left-0 right-0 h-full max-h-[97%] mx-[-1px]"
+          >
+            <div
+              className={clsx('flex flex-col max-w-md mx-auto w-full p-4 pt-5', {
+                'overflow-y-auto': snap === 1,
+                'overflow-hidden': snap !== 1,
+              })}
+            >
+              <div className="flex items-center">
+                <svg
+                  className="text-yellow-400 h-5 w-5 flex-shrink-0"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                    clip-rule="evenodd"
+                  ></path>
+                </svg>
+                <svg
+                  className="text-yellow-400 h-5 w-5 flex-shrink-0"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                    clip-rule="evenodd"
+                  ></path>
+                </svg>
+                <svg
+                  className="text-yellow-400 h-5 w-5 flex-shrink-0"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                    clip-rule="evenodd"
+                  ></path>
+                </svg>
+                <svg
+                  className="text-yellow-400 h-5 w-5 flex-shrink-0"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                    clip-rule="evenodd"
+                  ></path>
+                </svg>
+                <svg
+                  className="text-gray-300 h-5 w-5 flex-shrink-0"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401z"
+                    clip-rule="evenodd"
+                  ></path>
+                </svg>
+              </div>{' '}
+              <h1 className="text-2xl mt-2 font-medium">The Hidden Details</h1>
+              <p className="text-sm mt-1 text-gray-600 mb-6">2 modules, 27 hours of video</p>
+              <Drawer.SnapPoint offset={0} />
+              <p className="text-gray-600">
+                The world of user interface design is an intricate landscape filled with hidden details and nuance. In
+                this course, you will learn something cool. To the untrained eye, a beautifully designed UI.
+              </p>
+              <button className="bg-black text-gray-50 mt-8 rounded-md h-[48px] flex-shrink-0 font-medium">
+                Buy for $199
+              </button>
+              <div className="mt-12">
+                <h2 className="text-xl font-medium">Module 01. The Details</h2>
+                <div className="space-y-4 mt-4">
+                  <div>
+                    <span className="block">Layers of UI</span>
+                    <span className="text-gray-600">A basic introduction to Layers of Design.</span>
+                  </div>
+                  <div>
+                    <span className="block">Typography</span>
+                    <span className="text-gray-600">The fundamentals of type.</span>
+                  </div>
+                  <div>
+                    <span className="block">UI Animations</span>
+                    <span className="text-gray-600">Going through the right easings and durations.</span>
+                  </div>
+                </div>
+              </div>
+              <Drawer.SnapPoint offset={0} />
+              <div className="mt-12">
+                <figure>
+                  <blockquote className="font-serif">
+                    “I especially loved the hidden details video. That was so useful, learned a lot by just reading it.
+                    Can&rsquo;t wait for more course content!”
+                  </blockquote>
+                  <figcaption>
+                    <span className="text-sm text-gray-600 mt-2 block">Yvonne Ray, Frontend Developer</span>
+                  </figcaption>
+                </figure>
+              </div>
+              <div className="mt-12">
+                <h2 className="text-xl font-medium">Module 02. The Process</h2>
+                <div className="space-y-4 mt-4">
+                  <div>
+                    <span className="block">Build</span>
+                    <span className="text-gray-600">Create cool components to practice.</span>
+                  </div>
+                  <div>
+                    <span className="block">User Insight</span>
+                    <span className="text-gray-600">Find out what users think and fine-tune.</span>
+                  </div>
+                  <div>
+                    <span className="block">Putting it all together</span>
+                    <span className="text-gray-600">Let&apos;s build an app together and apply everything.</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer.Root>
+    </div>
+  );
+}

--- a/test/src/app/with-embedded-snap-points/page.tsx
+++ b/test/src/app/with-embedded-snap-points/page.tsx
@@ -97,6 +97,7 @@ export default function Page() {
               <button className="bg-black text-gray-50 mt-8 rounded-md h-[48px] flex-shrink-0 font-medium">
                 Buy for $199
               </button>
+              <Drawer.SnapPoint offset={24} />
               <div className="mt-12">
                 <h2 className="text-xl font-medium">Module 01. The Details</h2>
                 <div className="space-y-4 mt-4">
@@ -114,7 +115,6 @@ export default function Page() {
                   </div>
                 </div>
               </div>
-              <Drawer.SnapPoint offset={0} />
               <div className="mt-12">
                 <figure>
                   <blockquote className="font-serif">


### PR DESCRIPTION
## Problem

Hard coded `snapPoint` values are not ideal for responsive drawers. In the video bellow, notice how the snap point is not consistently under the "Buy" button when the screen is smaller.

https://github.com/user-attachments/assets/a6efab51-8bf5-459b-b255-255769a781f5

## Solution

Introduce a new `Drawer.SnapPoint` component to determine where the snaps occur based on their position in the DOM. This solution was inspired by this issue https://github.com/emilkowalski/vaul/issues/330

> [!CAUTION]
> Although functional, this PR is still a WIP as I find time to contribute.

## Todo
- [x] Define `<Drawer.SnapPoint />` 
- [x] Support `offset` prop in `<Drawer.SnapPoint />`
- [x] Add example inside `test` app
- [ ] Add tests around new feature
- [ ] Investigate how feature behaves with nested drawers
- [ ] Add comprehensive demo to PR

### Wishlist
- [ ] Support `name` prop in `<Drawer.SnapPoint />`
    -  The idea here is to allow the consumer to reference that snap point by name now that the point is dynamic.
- [x] Support a callback inside `snapPoints` prop to combine both hard coded and embedded snap points