### PR TITLE
fix: consider safe-area-inset in background scale animation when dragging

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -440,15 +440,15 @@ export function Root({
         const scaleValue = Math.min(getScale() + percentageDragged * (1 - getScale()), 1);
         const borderRadiusValue = 8 - percentageDragged * 8;
 
-        const translateValue = Math.max(0, 14 - percentageDragged * 14);
+        const translatePercent = 1 - percentageDragged;
 
         set(
           wrapper,
           {
             borderRadius: `${borderRadiusValue}px`,
             transform: isVertical(direction)
-              ? `scale(${scaleValue}) translate3d(0, ${translateValue}px, 0)`
-              : `scale(${scaleValue}) translate3d(${translateValue}px, 0, 0)`,
+              ? `scale(${scaleValue}) translate3d(0, calc((env(safe-area-inset-top) + 14px) * ${translatePercent}), 0)`
+              : `scale(${scaleValue}) translate3d(calc((env(safe-area-inset-top) + 14px) * ${translatePercent}), 0, 0)`,
             transition: 'none',
           },
           true,


### PR DESCRIPTION
### Description
Respects safe-area-inset on iOS when dragging. Previously the scaled background would jump.


https://github.com/user-attachments/assets/3d6096d7-f0c9-4cfc-b27a-10741c64db93

https://github.com/user-attachments/assets/78e2f8c3-a4ec-49f2-b015-864c8b0d5a11

