### PR TITLE
Update index.tsx to avoid accidental early return

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -804,14 +804,13 @@ export const Overlay = React.forwardRef<HTMLDivElement, React.ComponentPropsWith
     const { overlayRef, snapPoints, onRelease, shouldFade, isOpen, modal, shouldAnimate } = useDrawerContext();
     const composedRef = useComposedRefs(ref, overlayRef);
     const hasSnapPoints = snapPoints && snapPoints.length > 0;
+    const onMouseUp = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => onRelease(event), [onRelease]);
 
     // Overlay is the component that is locking scroll, removing it will unlock the scroll without having to dig into Radix's Dialog library
     if (!modal) {
       return null;
     }
-
-    const onMouseUp = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => onRelease(event), [onRelease]);
-
+    
     return (
       <DialogPrimitive.Overlay
         onMouseUp={onMouseUp}


### PR DESCRIPTION
let's say you have

```
const [hasModal, setHasModal] = useState<boolean>(true);

// ...
<Drawer.root modal={hasModal} ...>
// ...
<button onClick=(() => setHasModal(!hasModal)>toggle modal</button>
// ...
```

this will give you the following error

```
Unhandled Runtime Error
Error: Rendered fewer hooks than expected. This may be caused by an accidental early return statement.
```

this patch will address this error