### PR TITLE
Update playwright.yml to fix playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -18,7 +18,7 @@ jobs:
       - run: pnpm build
       - run: npx playwright install --with-deps
       - run: pnpm test || exit 1
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
see: https://github.com/orgs/community/discussions/152695

hopefully, it'll fix https://github.com/emilkowalski/vaul/actions/runs/13909868389/job/38921520070

```
Current runner version: '2.322.0'
Operating System
Runner Image
Runner Image Provisioner
GITHUB_TOKEN Permissions
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/checkout@v3' (SHA:f43a0e5ff[2](https://github.com/emilkowalski/vaul/actions/runs/13909868389/job/38921520070#step:1:2)bd294095638e18286ca9a3d195[6](https://github.com/emilkowalski/vaul/actions/runs/13909868389/job/38921520070#step:1:7)744)
Download action repository 'actions/setup-node@v3' (SHA:1a4442cacd436585916779262731d5b162bc6ec7)
Error: Missing download info for actions/upload-artifact@v3
```