### PR TITLE
fix: ensure modal={false} applies when using controlled open state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -737,13 +737,13 @@ export function Root({
   }
 
   React.useEffect(() => {
-    if (!modal) {
+    if (!modal && isOpen) {
       // Need to do this manually unfortunately
       window.requestAnimationFrame(() => {
         document.body.style.pointerEvents = 'auto';
       });
     }
-  }, [modal]);
+  }, [modal,isOpen]);
 
   return (
     <DialogPrimitive.Root


### PR DESCRIPTION
### What
Fixes an issue where `modal={false}` had no effect when using a controlled `open` prop.

### Why
Internally, the `modal` check only applied on initial mount. When controlling the drawer state using the `open` prop, pointer events were not correctly restored on open.

### How
Added `isOpen` as a dependency to the `useEffect` that applies `pointer-events: auto` when `modal` is false.

### Related
No open issue yet, but related to modal mode accessibility and pointer control.

---

Thanks for this great library! 😊
