### PR TITLE
Update playwright.yml

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,17 +8,19 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    container:
+        image: mcr.microsoft.com/playwright:v1.41.2
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - run: npm install -g pnpm@8.8.0
       - run: pnpm install
       - run: pnpm build
-      - run: npx playwright install --with-deps
+      - run: npx playwright install
       - run: pnpm test || exit 1
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
Ran into an issue that was fixed in #542, turns out it never got released due to what seems to be some deprecated actions

- See [similar issue](https://github.com/orgs/community/discussions/152695#discussioncomment-12469099)
- See [Deprecation notice: v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
- See [GitHub Actions: Transitioning from Node 16 to Node 20
](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)