### PR TITLE
fix: scale and scroll background wrapper as drawer is dragged when modal=false

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -435,7 +435,7 @@ export function Root({
         );
       }
 
-      if (wrapper && overlayRef.current && shouldScaleBackground) {
+      if (wrapper && shouldScaleBackground) {
         // Calculate percentageDragged as a fraction (0 to 1)
         const scaleValue = Math.min(getScale() + percentageDragged * (1 - getScale()), 1);
         const borderRadiusValue = 8 - percentageDragged * 8;


### PR DESCRIPTION
Currently, when modal=false, the background is not scaled with the drawer as it is dragged up/down. This fix ensures proper scaling behavior even when modal=false.