### PR TITLE
Dont allow negative drag values

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -411,7 +411,10 @@ export function Root({
       if (isDraggingInDirection && !snapPoints) {
         const dampenedDraggedDistance = dampenValue(draggedDistance);
 
-        const translateValue = Math.min(dampenedDraggedDistance * -1, 0) * directionMultiplier;
+        let translateValue = Math.min(dampenedDraggedDistance * -1, 0) * directionMultiplier;
+        if (translateValue < 0) {
+          translateValue = 0;
+        }
         set(drawerRef.current, {
           transform: isVertical(direction)
             ? `translate3d(0, ${translateValue}px, 0)`


### PR DESCRIPTION
When you start to drag-to-close the drawer down and change direction to up you can detach it from the bottom of the screen.
Is there any use-case where this is intended behavior? If so I could add a prop control it.