### PR TITLE
fix: enable SSR support for Vaul without using Portal

### DIFF
--- a/src/use-scale-background.ts
+++ b/src/use-scale-background.ts
@@ -8,7 +8,7 @@ const noop = () => () => {};
 export function useScaleBackground() {
   const { direction, isOpen, shouldScaleBackground, setBackgroundColorOnScale, noBodyStyles } = useDrawerContext();
   const timeoutIdRef = React.useRef<number | null>(null);
-  const initialBackgroundColor = useMemo(() => document.body.style.backgroundColor, []);
+  const initialBackgroundColor = useMemo(() => typeof document === "undefined" ? undefined : document.body.style.backgroundColor, []);
 
   function getScale() {
     return (window.innerWidth - WINDOW_TOP_OFFSET) / window.innerWidth;


### PR DESCRIPTION
When attempting to use Vaul in SSR (Server-Side Rendering) mode without Portal, the application throws an error due to direct access to the document object, which is not available in a server environment.

This commit addresses that issue by ensuring that document is defined. This allows Vaul to render content directly into the DOM during SSR, which is critical for SEO purposes.

This fix makes it possible to safely render Vaul modals server-side without relying on a Portal, improving compatibility with SSR frameworks (like Next.js) and better supporting SEO-sensitive use cases.