### PR TITLE
feat: execute `onDrag` not based on any condition for better usage

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -386,6 +386,9 @@ export function Root({
         percentageDragged = snapPointPercentageDragged;
       }
 
+      // Execute onDragProp if it's defined
+      if (onDragProp) onDragProp(event, percentageDragged);
+
       // Disallow close dragging beyond the smallest snap point.
       if (noCloseSnapPointsPreCondition && percentageDragged >= 1) {
         return;
@@ -423,8 +426,6 @@ export function Root({
       const opacityValue = 1 - percentageDragged;
 
       if (shouldFade || (fadeFromIndex && activeSnapPointIndex === fadeFromIndex - 1)) {
-        onDragProp?.(event, percentageDragged);
-
         set(
           overlayRef.current,
           {


### PR DESCRIPTION
Why are we execute `onDrag` based on fade condition? Why don't we just execute it if defined? This make more sense to me and better usage too for `onDrag`